### PR TITLE
CPU SIMD optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 ##################################################
 # Dependencies
 
+# Prefer the venv Python so that CTest and check-runko use the same
+# interpreter (with mpi4py, numpy, etc.) that developers activate locally.
+set(Python_FIND_VIRTUALENV FIRST)
 find_package (Python COMPONENTS Interpreter Development REQUIRED)
 
 find_package(OpenMP REQUIRED)
@@ -83,6 +86,7 @@ include(CTest)
 add_subdirectory(tests/multirank_tests)
 
 add_custom_target(check-runko ALL
+                  ${CMAKE_COMMAND} -E env "PYTHONPATH=${PROJECT_SOURCE_DIR}"
                   ${Python_EXECUTABLE} -m unittest discover -s ../tests/ -v
                   DEPENDS pycorgi runko_cpp_bindings
                   VERBATIM

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -50,7 +50,7 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_CXX_FLAGS": "-O3 -march=native -mllvm -force-vector-width=4 -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize",
-                "BUILD_TESTING": "OFF"
+                "BUILD_TESTING": "ON"
             }
         }
     ],
@@ -73,6 +73,13 @@
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
             "configurePreset": "macos-mpic++-debug"
+        },
+        {
+            "name": "test-macos-mpic++-vec-analysis",
+            "displayName": "mpic++ Vectorization Analysis (macOS)",
+            "description": "Enable output and stop on failure",
+            "inherits": "test-common",
+            "configurePreset": "macos-mpic++-vec-analysis"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,6 +34,7 @@
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "mpic++",
                 "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS": "-mllvm -force-vector-width=4",
                 "tyvi_ENABLE_IPO": "OFF",
                 "tyvi_ENABLE_CLANG_TIDY": "OFF",
                 "tyvi_ENABLE_CPPCHECK": "OFF",
@@ -48,7 +49,7 @@
             "inherits": "macos-mpic++-debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_CXX_FLAGS": "-O3 -march=native -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize",
+                "CMAKE_CXX_FLAGS": "-O3 -march=native -mllvm -force-vector-width=4 -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize",
                 "BUILD_TESTING": "OFF"
             }
         }

--- a/bindings/pyemf.c++
+++ b/bindings/pyemf.c++
@@ -144,7 +144,7 @@ void
           auto vec      = std::vector<std::complex<emf::antenna_mode::value_type>>(N);
           const auto pv = p.template unchecked<1>();
 
-          for(auto i = 0uz; i < N; ++i) { vec[i] = pv(i); }
+          for(auto i = 0u; i < N; ++i) { vec[i] = pv(i); }
           return vec;
         };
 
@@ -161,7 +161,7 @@ void
   // 3d tile
   py::class_<emf::Tile<3>, corgi::Tile<3>, std::shared_ptr<emf::Tile<3>>>(m_3d, "Tile")
     .def(
-      py::init([](const std::array<std::size_t, 3> tile_grid_idx, const py::handle& h) {
+      py::init([](const std::array<runko::size_t, 3> tile_grid_idx, const py::handle& h) {
         return emf::Tile<3>(tile_grid_idx, toolbox::ConfigParser(h));
       }))
     .def("set_EBJ", &emf::Tile<3>::set_EBJ)

--- a/bindings/pyemf.c++
+++ b/bindings/pyemf.c++
@@ -161,7 +161,7 @@ void
   // 3d tile
   py::class_<emf::Tile<3>, corgi::Tile<3>, std::shared_ptr<emf::Tile<3>>>(m_3d, "Tile")
     .def(
-      py::init([](const std::array<runko::size_t, 3> tile_grid_idx, const py::handle& h) {
+      py::init([](const std::array<std::size_t, 3> tile_grid_idx, const py::handle& h) {
         return emf::Tile<3>(tile_grid_idx, toolbox::ConfigParser(h));
       }))
     .def("set_EBJ", &emf::Tile<3>::set_EBJ)

--- a/bindings/pypic.c++
+++ b/bindings/pypic.c++
@@ -80,18 +80,18 @@ void
     corgi::Tile<3>,
     std::shared_ptr<pic::Tile<3>>>(m_3d, "Tile")
     .def(
-      py::init([](const std::array<runko::size_t, 3> tile_grid_idx, const py::handle& h) {
+      py::init([](const std::array<std::size_t, 3> tile_grid_idx, const py::handle& h) {
         return pic::Tile<3>(tile_grid_idx, toolbox::ConfigParser(h));
       }))
     .def(
       "get_positions",
-      [](pic::Tile<3>& tile, const runko::size_t p) {
+      [](pic::Tile<3>& tile, const std::size_t p) {
         const auto [x, y, z] = tile.get_positions(p);
         return std::tuple { to_ndarray(x), to_ndarray(y), to_ndarray(z) };
       })
     .def(
       "get_velocities",
-      [](pic::Tile<3>& tile, const runko::size_t p) {
+      [](pic::Tile<3>& tile, const std::size_t p) {
         const auto [x, y, z] = tile.get_velocities(p);
         return std::tuple { to_ndarray(x), to_ndarray(y), to_ndarray(z) };
       })

--- a/bindings/pypic.c++
+++ b/bindings/pypic.c++
@@ -24,7 +24,7 @@ auto
   auto mda              = py::array_t<T, py::array::c_style>(grid_shape);
   auto mda_mut          = mda.template mutable_unchecked<1>();
 
-  for(const auto i: std::views::iota(0uz, vec.size())) { mda_mut(i) = vec[i]; }
+  for(const auto i: std::views::iota(0u, vec.size())) { mda_mut(i) = vec[i]; }
 
   return std::move(mda);
 }
@@ -80,18 +80,18 @@ void
     corgi::Tile<3>,
     std::shared_ptr<pic::Tile<3>>>(m_3d, "Tile")
     .def(
-      py::init([](const std::array<std::size_t, 3> tile_grid_idx, const py::handle& h) {
+      py::init([](const std::array<runko::size_t, 3> tile_grid_idx, const py::handle& h) {
         return pic::Tile<3>(tile_grid_idx, toolbox::ConfigParser(h));
       }))
     .def(
       "get_positions",
-      [](pic::Tile<3>& tile, const std::size_t p) {
+      [](pic::Tile<3>& tile, const runko::size_t p) {
         const auto [x, y, z] = tile.get_positions(p);
         return std::tuple { to_ndarray(x), to_ndarray(y), to_ndarray(z) };
       })
     .def(
       "get_velocities",
-      [](pic::Tile<3>& tile, const std::size_t p) {
+      [](pic::Tile<3>& tile, const runko::size_t p) {
         const auto [x, y, z] = tile.get_velocities(p);
         return std::tuple { to_ndarray(x), to_ndarray(y), to_ndarray(z) };
       })

--- a/core/emf/tile.c++
+++ b/core/emf/tile.c++
@@ -37,8 +37,8 @@ emf::CurrentFilter
 {
   if(p == "binomial2") {
     return emf::CurrentFilter::binomial2;
-  } else if(p == "binomial2_3d") {
-    return emf::CurrentFilter::binomial2_3d;
+  } else if(p == "binomial2_unrolled") {
+    return emf::CurrentFilter::binomial2_unrolled;
   } else {
     const auto msg = std::format("{} is not supported current filter.", p);
     throw std::runtime_error { msg };
@@ -354,8 +354,8 @@ void
     case emf::CurrentFilter::binomial2:
       this->yee_lattice_.filter_current_binomial2();
       return;
-    case emf::CurrentFilter::binomial2_3d:
-      this->yee_lattice_.filter_current_binomial2_3d();
+    case emf::CurrentFilter::binomial2_unrolled:
+      this->yee_lattice_.filter_current_binomial2_unrolled();
       return;
     default:
       throw std::logic_error {

--- a/core/emf/tile.c++
+++ b/core/emf/tile.c++
@@ -37,6 +37,8 @@ emf::CurrentFilter
 {
   if(p == "binomial2") {
     return emf::CurrentFilter::binomial2;
+  } else if(p == "binomial2_3d") {
+    return emf::CurrentFilter::binomial2_3d;
   } else {
     const auto msg = std::format("{} is not supported current filter.", p);
     throw std::runtime_error { msg };
@@ -351,6 +353,9 @@ void
   switch(cf) {
     case emf::CurrentFilter::binomial2:
       this->yee_lattice_.filter_current_binomial2();
+      return;
+    case emf::CurrentFilter::binomial2_3d:
+      this->yee_lattice_.filter_current_binomial2_3d();
       return;
     default:
       throw std::logic_error {

--- a/core/emf/tile.c++
+++ b/core/emf/tile.c++
@@ -74,14 +74,14 @@ namespace emf {
 
 template<std::size_t D>
 Tile<D>::Tile(
-  const std::array<runko::size_t, 3> tile_indices,
+  const std::array<std::size_t, 3> tile_indices,
   const toolbox::ConfigParser& p) :
   corgi::Tile<D>(),
   yee_lattice_(
     YeeLatticeCtorArgs { .halo_size = halo_size,
-                         .Nx        = p.get_or_throw<runko::size_t>("NxMesh"),
-                         .Ny        = p.get_or_throw<runko::size_t>("NyMesh"),
-                         .Nz        = p.get_or_throw<runko::size_t>("NzMesh")
+                         .Nx        = p.get_or_throw<std::size_t>("NxMesh"),
+                         .Ny        = p.get_or_throw<std::size_t>("NyMesh"),
+                         .Nz        = p.get_or_throw<std::size_t>("NzMesh")
 
     }),
   cfl_ { p.get_or_throw<double>("cfl") },
@@ -112,9 +112,9 @@ Tile<D>::Tile(
 
   const auto [i, j, k] = tile_indices;
 
-  const auto Nx = p.get_or_throw<runko::size_t>("Nx");
-  const auto Ny = p.get_or_throw<runko::size_t>("Ny");
-  const auto Nz = p.get_or_throw<runko::size_t>("Nz");
+  const auto Nx = p.get_or_throw<std::size_t>("Nx");
+  const auto Ny = p.get_or_throw<std::size_t>("Ny");
+  const auto Nz = p.get_or_throw<std::size_t>("Nz");
 
   if(Nx <= i or Ny <= j or Nz <= k) {
     throw std::runtime_error { "Trying to create tile outside of configured grid." };
@@ -152,7 +152,7 @@ void
 
   const auto global_coordinates = global_coordinate_map();
 
-  auto f = [&](const runko::size_t i, const runko::size_t j, const runko::size_t k) {
+  auto f = [&](const runko::index_t i, const runko::index_t j, const runko::index_t k) {
     const auto [x, y, z] = global_coordinates(i, j, k);
     const auto ex        = E(x + 0.5, y, z);
     const auto ey        = E(x, y + 0.5, z);
@@ -242,7 +242,7 @@ void
   const auto jz = Jz(x, y, zp5);
 
   const auto assert_shape = [&](const auto& A) {
-    if(static_cast<runko::size_t>(A.shape(0)) != e[0] or static_cast<runko::size_t>(A.shape(1)) != e[1] or static_cast<runko::size_t>(A.shape(2)) != e[2]) {
+    if(static_cast<std::size_t>(A.shape(0)) != e[0] or static_cast<std::size_t>(A.shape(1)) != e[1] or static_cast<std::size_t>(A.shape(2)) != e[2]) {
       throw std::runtime_error {
         "Batch field setter returned array with incorrect shape!"
       };
@@ -270,7 +270,7 @@ void
   const auto jzv = jz.template unchecked<3>();
 
 
-  auto f = [&](const runko::size_t i, const runko::size_t j, const runko::size_t k) {
+  auto f = [&](const runko::index_t i, const runko::index_t j, const runko::index_t k) {
     return YeeLatticeFieldsAtPoint { .Ex = exv(i, j, k),
                                      .Ey = eyv(i, j, k),
                                      .Ez = ezv(i, j, k),
@@ -300,7 +300,7 @@ YeeLattice::YeeLatticeHostCopy
 }
 
 template<std::size_t D>
-std::array<runko::size_t, 3>
+std::array<std::size_t, 3>
   Tile<D>::extents_wout_halo() const
 {
   return yee_lattice_.extents_wout_halo();

--- a/core/emf/tile.c++
+++ b/core/emf/tile.c++
@@ -370,7 +370,7 @@ std::vector<mpi4cpp::mpi::request>
 
   // GPU backend requires GPU-aware MPI to pass device pointers directly;
   // CPU backend uses host memory where standard MPI works.
-#ifndef TYVI_USE_CPU_BACKEND
+#ifndef TYVI_BACKEND_CPU
   if(not toolbox::system_supports_gpu_aware_mpi()) {
     throw std::runtime_error {
       "GPU backend requires GPU-aware MPI."
@@ -403,7 +403,7 @@ std::vector<mpi4cpp::mpi::request>
     const int mode,
     const int tag)
 {
-#ifndef TYVI_USE_CPU_BACKEND
+#ifndef TYVI_BACKEND_CPU
   if(not toolbox::system_supports_gpu_aware_mpi()) {
     throw std::runtime_error {
       "GPU backend requires GPU-aware MPI."

--- a/core/emf/tile.c++
+++ b/core/emf/tile.c++
@@ -72,14 +72,14 @@ namespace emf {
 
 template<std::size_t D>
 Tile<D>::Tile(
-  const std::array<std::size_t, 3> tile_indices,
+  const std::array<runko::size_t, 3> tile_indices,
   const toolbox::ConfigParser& p) :
   corgi::Tile<D>(),
   yee_lattice_(
     YeeLatticeCtorArgs { .halo_size = halo_size,
-                         .Nx        = p.get_or_throw<std::size_t>("NxMesh"),
-                         .Ny        = p.get_or_throw<std::size_t>("NyMesh"),
-                         .Nz        = p.get_or_throw<std::size_t>("NzMesh")
+                         .Nx        = p.get_or_throw<runko::size_t>("NxMesh"),
+                         .Ny        = p.get_or_throw<runko::size_t>("NyMesh"),
+                         .Nz        = p.get_or_throw<runko::size_t>("NzMesh")
 
     }),
   cfl_ { p.get_or_throw<double>("cfl") },
@@ -110,9 +110,9 @@ Tile<D>::Tile(
 
   const auto [i, j, k] = tile_indices;
 
-  const auto Nx = p.get_or_throw<std::size_t>("Nx");
-  const auto Ny = p.get_or_throw<std::size_t>("Ny");
-  const auto Nz = p.get_or_throw<std::size_t>("Nz");
+  const auto Nx = p.get_or_throw<runko::size_t>("Nx");
+  const auto Ny = p.get_or_throw<runko::size_t>("Ny");
+  const auto Nz = p.get_or_throw<runko::size_t>("Nz");
 
   if(Nx <= i or Ny <= j or Nz <= k) {
     throw std::runtime_error { "Trying to create tile outside of configured grid." };
@@ -125,7 +125,7 @@ Tile<D>::Tile(
 
   this->set_tile_mins({ xmin + i * Lx, ymin + j * Ly, zmin + k * Lz });
   this->set_tile_maxs(
-    { xmin + (i + 1uz) * Lx, ymin + (j + 1uz) * Ly, zmin + (k + 1uz) * Lz });
+    { xmin + (i + 1u) * Lx, ymin + (j + 1u) * Ly, zmin + (k + 1u) * Lz });
 
 
   this->global_coordinate_mins_ = { xmin, ymin, zmin };
@@ -150,7 +150,7 @@ void
 
   const auto global_coordinates = global_coordinate_map();
 
-  auto f = [&](const std::size_t i, const std::size_t j, const std::size_t k) {
+  auto f = [&](const runko::size_t i, const runko::size_t j, const runko::size_t k) {
     const auto [x, y, z] = global_coordinates(i, j, k);
     const auto ex        = E(x + 0.5, y, z);
     const auto ey        = E(x, y + 0.5, z);
@@ -240,7 +240,7 @@ void
   const auto jz = Jz(x, y, zp5);
 
   const auto assert_shape = [&](const auto& A) {
-    if(static_cast<std::size_t>(A.shape(0)) != e[0] or static_cast<std::size_t>(A.shape(1)) != e[1] or static_cast<std::size_t>(A.shape(2)) != e[2]) {
+    if(static_cast<runko::size_t>(A.shape(0)) != e[0] or static_cast<runko::size_t>(A.shape(1)) != e[1] or static_cast<runko::size_t>(A.shape(2)) != e[2]) {
       throw std::runtime_error {
         "Batch field setter returned array with incorrect shape!"
       };
@@ -268,7 +268,7 @@ void
   const auto jzv = jz.template unchecked<3>();
 
 
-  auto f = [&](const std::size_t i, const std::size_t j, const std::size_t k) {
+  auto f = [&](const runko::size_t i, const runko::size_t j, const runko::size_t k) {
     return YeeLatticeFieldsAtPoint { .Ex = exv(i, j, k),
                                      .Ey = eyv(i, j, k),
                                      .Ez = ezv(i, j, k),
@@ -298,7 +298,7 @@ YeeLattice::YeeLatticeHostCopy
 }
 
 template<std::size_t D>
-std::array<std::size_t, 3>
+std::array<runko::size_t, 3>
   Tile<D>::extents_wout_halo() const
 {
   return yee_lattice_.extents_wout_halo();
@@ -522,9 +522,9 @@ void
     return std::visit(handle_wave_data, wm.wave_data);
   };
 
-  for(const auto n: std::views::iota(0uz, num_of_modes)) {
+  for(const auto n: std::views::iota(0u, num_of_modes)) {
     const auto wave_vector = get_wave_vector(this->antenna_modes_[n]);
-    for(const auto i: std::views::iota(0uz, 3uz)) {
+    for(const auto i: std::views::iota(0u, 3u)) {
       sA_mds[n][i] =
         static_cast<emf::YeeLattice::value_type>(this->antenna_modes_[n].A[i]);
       sk_mds[n][i] = static_cast<emf::YeeLattice::value_type>(wave_vector[i]);
@@ -576,7 +576,7 @@ void
     const auto z_loc = vec(gcmap(i, j, k + 0.5));
 
 
-    for(auto n = 0uz; n < num_of_modes; ++n) {
+    for(auto n = 0u; n < num_of_modes; ++n) {
       // std::complex is contexpr only in c++26 and thus not usable in kernel.
       // Here we do manual complex arithmeitc as a work around.
 
@@ -618,13 +618,13 @@ void
   const auto h = this->halo_size;
 
   const auto [ex, ey, ez] = this->extents_wout_halo();
-  const auto i1           = std::tuple { h - 1uz, h + ex + 1uz };
-  const auto j1           = std::tuple { h - 1uz, h + ey + 1uz };
-  const auto k1           = std::tuple { h - 1uz, h + ez + 1uz };
+  const auto i1           = std::tuple { h - 1u, h + ex + 1u };
+  const auto j1           = std::tuple { h - 1u, h + ey + 1u };
+  const auto k1           = std::tuple { h - 1u, h + ez + 1u };
 
-  const auto i1p1 = std::tuple { h, h + ex + 2uz };
-  const auto j1p1 = std::tuple { h, h + ey + 2uz };
-  const auto k1p1 = std::tuple { h, h + ez + 2uz };
+  const auto i1p1 = std::tuple { h, h + ex + 2u };
+  const auto j1p1 = std::tuple { h, h + ey + 2u };
+  const auto k1p1 = std::tuple { h, h + ez + 2u };
 
   // FIXME: unify this with emf FDTD2.
   auto curl = [&](
@@ -666,9 +666,9 @@ void
   const auto i   = std::tuple { h, h + ex };
   const auto j   = std::tuple { h, h + ey };
   const auto k   = std::tuple { h, h + ez };
-  const auto im1 = std::tuple { h - 1uz, h + ex - 1uz };
-  const auto jm1 = std::tuple { h - 1uz, h + ey - 1uz };
-  const auto km1 = std::tuple { h - 1uz, h + ez - 1uz };
+  const auto im1 = std::tuple { h - 1u, h + ex - 1u };
+  const auto jm1 = std::tuple { h - 1u, h + ey - 1u };
+  const auto km1 = std::tuple { h - 1u, h + ez - 1u };
 
   // Here we negate cfl, as we put (im1, jm1, km1) instead of (ip1, jp1, kp1).
   curl(

--- a/core/emf/tile.h
+++ b/core/emf/tile.h
@@ -56,7 +56,7 @@ public:
   /// `d{x,y,z}`: coordinate distance between mesh/grid points
   /// `field_propagator`: scheme to propagate E and B fields.
   explicit Tile(
-    std::array<runko::size_t, 3> tile_grid_indices,
+    std::array<std::size_t, 3> tile_grid_indices,
     const toolbox::ConfigParser& config);
 
   // Has to be explicitly declared as a work around for hipcc bug.
@@ -96,7 +96,7 @@ public:
   auto view_EBJ_on_host() { return yee_lattice_.view_EBJ_on_host(); }
 
   /// Size of the non-halo yee lattice.
-  std::array<runko::size_t, 3> extents_wout_halo() const;
+  std::array<std::size_t, 3> extents_wout_halo() const;
 
   /// Advance B by half time step using scheme from configuration in non-halo region.
   void push_half_b();

--- a/core/emf/tile.h
+++ b/core/emf/tile.h
@@ -18,7 +18,7 @@
 namespace emf {
 
 enum class FieldPropagator { FDTD2 };
-enum class CurrentFilter { binomial2, binomial2_3d };
+enum class CurrentFilter { binomial2, binomial2_unrolled };
 
 /*! \brief General Plasma tile for solving Maxwell's equations
  *

--- a/core/emf/tile.h
+++ b/core/emf/tile.h
@@ -18,7 +18,7 @@
 namespace emf {
 
 enum class FieldPropagator { FDTD2 };
-enum class CurrentFilter { binomial2 };
+enum class CurrentFilter { binomial2, binomial2_3d };
 
 /*! \brief General Plasma tile for solving Maxwell's equations
  *

--- a/core/emf/tile.h
+++ b/core/emf/tile.h
@@ -56,7 +56,7 @@ public:
   /// `d{x,y,z}`: coordinate distance between mesh/grid points
   /// `field_propagator`: scheme to propagate E and B fields.
   explicit Tile(
-    std::array<std::size_t, 3> tile_grid_indices,
+    std::array<runko::size_t, 3> tile_grid_indices,
     const toolbox::ConfigParser& config);
 
   // Has to be explicitly declared as a work around for hipcc bug.
@@ -96,7 +96,7 @@ public:
   auto view_EBJ_on_host() { return yee_lattice_.view_EBJ_on_host(); }
 
   /// Size of the non-halo yee lattice.
-  std::array<std::size_t, 3> extents_wout_halo() const;
+  std::array<runko::size_t, 3> extents_wout_halo() const;
 
   /// Advance B by half time step using scheme from configuration in non-halo region.
   void push_half_b();

--- a/core/emf/yee_lattice.c++
+++ b/core/emf/yee_lattice.c++
@@ -74,20 +74,20 @@ YeeLattice::YeeLattice(const YeeLatticeCtorArgs args) :
   }
 }
 
-std::array<runko::size_t, 3>
+std::array<std::size_t, 3>
   YeeLattice::extents_wout_halo() const
 {
   return extents_wout_halo_;
 }
-std::array<runko::size_t, 3>
+std::array<std::size_t, 3>
   YeeLattice::extents_with_halo() const
 {
   auto e        = extents_wout_halo();
-  auto add_halo = [this](const auto x) { return x + 2u * halo_size(); };
+  auto add_halo = [this](const auto x) { return x + 2uz * halo_size(); };
   std::ranges::transform(e, e.begin(), add_halo);
   return e;
 }
-runko::size_t
+std::size_t
   YeeLattice::halo_size() const
 {
   return halo_size_;

--- a/core/emf/yee_lattice.c++
+++ b/core/emf/yee_lattice.c++
@@ -52,14 +52,14 @@ YeeLattice::YeeLattice(const YeeLatticeCtorArgs args) :
   halo_size_ { args.halo_size },
   extents_wout_halo_ { args.Nx, args.Ny, args.Nz },
   E_(
-    args.Nx + 2uz * halo_size_,
-    args.Ny + 2uz * halo_size_,
-    args.Nz + 2uz * halo_size_),
+    args.Nx + 2u * halo_size_,
+    args.Ny + 2u * halo_size_,
+    args.Nz + 2u * halo_size_),
   B_(
-    args.Nx + 2uz * halo_size_,
-    args.Ny + 2uz * halo_size_,
-    args.Nz + 2uz * halo_size_),
-  J_(args.Nx + 2uz * halo_size_, args.Ny + 2uz * halo_size_, args.Nz + 2uz * halo_size_)
+    args.Nx + 2u * halo_size_,
+    args.Ny + 2u * halo_size_,
+    args.Nz + 2u * halo_size_),
+  J_(args.Nx + 2u * halo_size_, args.Ny + 2u * halo_size_, args.Nz + 2u * halo_size_)
 {
 
   auto less_than_halo = [this](const auto x) { return x < halo_size_; };
@@ -74,20 +74,20 @@ YeeLattice::YeeLattice(const YeeLatticeCtorArgs args) :
   }
 }
 
-std::array<std::size_t, 3>
+std::array<runko::size_t, 3>
   YeeLattice::extents_wout_halo() const
 {
   return extents_wout_halo_;
 }
-std::array<std::size_t, 3>
+std::array<runko::size_t, 3>
   YeeLattice::extents_with_halo() const
 {
   auto e        = extents_wout_halo();
-  auto add_halo = [this](const auto x) { return x + 2uz * halo_size(); };
+  auto add_halo = [this](const auto x) { return x + 2u * halo_size(); };
   std::ranges::transform(e, e.begin(), add_halo);
   return e;
 }
-std::size_t
+runko::size_t
   YeeLattice::halo_size() const
 {
   return halo_size_;

--- a/core/emf/yee_lattice.h
+++ b/core/emf/yee_lattice.h
@@ -279,20 +279,17 @@ public:
   /// Throws if given grid is not same size as the lattice with halo.
   void deposit_current(const tyvi::mdgrid_work&, const runko::VecGrid<value_type>&);
 
-  /// Apply digital 2nd order one-pass binomial filter for J.
+  /// Apply digital 2nd order binomial filter for J using a single 3D kernel.
   void filter_current_binomial2();
 
-  /// Apply digital 2nd order one-pass binomial filter for J asynchronouosly.
-  ///
-  /// Asynchronously  means that work is executed on the given work which is
-  /// synchronized before returning.
+  /// Apply digital 2nd order binomial filter for J using a single 3D kernel (async).
   void filter_current_binomial2(const tyvi::mdgrid_work&);
 
-  /// Apply digital 2nd order binomial filter for J using a single 3D kernel.
-  void filter_current_binomial2_3d();
+  /// Apply digital 2nd order binomial filter for J with manually unrolled separable passes.
+  void filter_current_binomial2_unrolled();
 
-  /// Apply digital 2nd order binomial filter for J using a single 3D kernel (async).
-  void filter_current_binomial2_3d(const tyvi::mdgrid_work&);
+  /// Apply digital 2nd order binomial filter for J with manually unrolled separable passes (async).
+  void filter_current_binomial2_unrolled(const tyvi::mdgrid_work&);
 
   /// Returns mdspans to host accessible E, B and J in non-halo region.
   auto view_EBJ_on_host();

--- a/core/emf/yee_lattice.h
+++ b/core/emf/yee_lattice.h
@@ -274,6 +274,12 @@ public:
   /// synchronized before returning.
   void filter_current_binomial2(const tyvi::mdgrid_work&);
 
+  /// Apply digital 2nd order binomial filter for J using a single 3D kernel.
+  void filter_current_binomial2_3d();
+
+  /// Apply digital 2nd order binomial filter for J using a single 3D kernel (async).
+  void filter_current_binomial2_3d(const tyvi::mdgrid_work&);
+
   /// Returns mdspans to host accessible E, B and J in non-halo region.
   auto view_EBJ_on_host();
 

--- a/core/emf/yee_lattice.h
+++ b/core/emf/yee_lattice.h
@@ -231,6 +231,20 @@ public:
     std::array<value_type, 3> lattice_origo_coordinates,
     const runko::VecList<value_type>& coordinates) const;
 
+  /// Interpolate E and B using linear_1st with manually unrolled 2x2x2 stencil.
+  ///
+  /// Bit-exact results as linear_1st but the unrolled stencil enables
+  /// SIMD vectorization of the outer particle loop.
+  InterpolatedEB interpolate_EB_linear_1st_unrolled(
+    std::array<value_type, 3> lattice_origo_coordinates,
+    const runko::VecList<value_type>& coordinates) const;
+
+  /// Interpolate E and B using linear_1st with manually unrolled 2x2x2 stencil (async).
+  InterpolatedEB interpolate_EB_linear_1st_unrolled(
+    const tyvi::mdgrid_work&,
+    std::array<value_type, 3> lattice_origo_coordinates,
+    const runko::VecList<value_type>& coordinates) const;
+
   /// Set J = 0 everywhere including in halo.
   void clear_current();
 

--- a/core/emf/yee_lattice.h
+++ b/core/emf/yee_lattice.h
@@ -19,8 +19,8 @@
 namespace emf {
 
 struct YeeLatticeCtorArgs {
-  std::size_t halo_size {};
-  std::size_t Nx {}, Ny {}, Nz {};
+  runko::size_t halo_size {};
+  runko::size_t Nx {}, Ny {}, Nz {};
 };
 
 struct YeeLatticeFieldsAtPoint {
@@ -35,9 +35,9 @@ struct YeeLatticeFieldsAtPoint {
 /// in the Yee Lattice.
 template<typename F>
 concept yee_lattice_fields_function =
-  std::invocable<F, std::size_t, std::size_t, std::size_t> and
+  std::invocable<F, runko::size_t, runko::size_t, runko::size_t> and
   std::same_as<
-    std::invoke_result_t<F, std::size_t, std::size_t, std::size_t>,
+    std::invoke_result_t<F, runko::size_t, runko::size_t, runko::size_t>,
     YeeLatticeFieldsAtPoint>;
 
 /// Yee lattice of plasma quantities in tyvi::mdgrid continers.
@@ -49,7 +49,7 @@ public:
 
   using YeeLatticeHostCopy = tyvi::mdgrid_buffer<
     std::vector<YeeLatticeFieldsAtPoint>,
-    std::extents<std::size_t>,
+    std::extents<runko::size_t>,
     std::layout_right,
     VecGrid::grid_extents_type,
     VecGrid::grid_layout_type>;
@@ -68,8 +68,8 @@ public:
   }
 
 private:
-  std::size_t halo_size_;
-  std::array<std::size_t, 3> extents_wout_halo_;
+  runko::size_t halo_size_;
+  std::array<runko::size_t, 3> extents_wout_halo_;
 
 
   /// Electric field
@@ -119,9 +119,9 @@ private:
 public:
   explicit YeeLattice(YeeLatticeCtorArgs);
 
-  [[nodiscard]] std::array<std::size_t, 3> extents_wout_halo() const;
-  [[nodiscard]] std::array<std::size_t, 3> extents_with_halo() const;
-  [[nodiscard]] std::size_t halo_size() const;
+  [[nodiscard]] std::array<runko::size_t, 3> extents_wout_halo() const;
+  [[nodiscard]] std::array<runko::size_t, 3> extents_with_halo() const;
+  [[nodiscard]] runko::size_t halo_size() const;
 
   /// Initializes E, B and J in non-halo region.
   void set_EBJ(yee_lattice_fields_function auto&& f);
@@ -239,7 +239,7 @@ public:
 
   /// Represents a set of locations and corresponding currents.
   struct [[nodiscard]] CurrentContributions {
-    thrust::device_vector<std::array<std::size_t, 3>> locations;
+    thrust::device_vector<std::array<runko::size_t, 3>> locations;
     thrust::device_vector<std::array<value_type, 3>> currents;
   };
 
@@ -347,8 +347,8 @@ void
   YeeLattice::assert_mds_spans_whole_lattice(const auto& mds) const
 {
   const auto mds_extents =
-    std::views::iota(0uz, mds.rank()) |
-    std::views::transform([&](const std::size_t i) { return mds.extent(i); });
+    std::views::iota(0u, mds.rank()) |
+    std::views::transform([&](const runko::size_t i) { return mds.extent(i); });
 
 
   if(not std::ranges::equal(mds_extents, extents_with_halo())) {
@@ -363,13 +363,13 @@ auto
   assert_mds_spans_whole_lattice(mds);
 
   auto oneD_dir_to_index_extent =
-    [&, this](const std::size_t i) -> std::tuple<std::size_t, std::size_t> {
+    [&, this](const runko::size_t i) -> std::tuple<runko::size_t, runko::size_t> {
     switch(dir[i]) {
-      case -1: return { 0uz, halo_size_ };
+      case -1: return { 0u, halo_size_ };
       case 0: return { halo_size_, halo_size_ + extents_wout_halo_[i] };
       case 1:
         return { halo_size_ + extents_wout_halo_[i],
-                 2uz * halo_size_ + extents_wout_halo_[i] };
+                 2u * halo_size_ + extents_wout_halo_[i] };
       default:
         throw std::logic_error { std::format("dir[{}] = {} != -1, 0 or 1", i, dir[i]) };
     }
@@ -442,7 +442,7 @@ inline auto
   assert_mds_spans_whole_lattice(mds);
 
   auto oneD_dir_to_index_extent =
-    [&, this](const std::size_t i) -> std::tuple<std::size_t, std::size_t> {
+    [&, this](const runko::size_t i) -> std::tuple<runko::size_t, runko::size_t> {
     switch(invert_dir(dir)[i]) {
       case -1: return { halo_size_, 2u * halo_size_ };
       case 0: return { halo_size_, halo_size_ + extents_wout_halo_[i] };

--- a/core/emf/yee_lattice.h
+++ b/core/emf/yee_lattice.h
@@ -19,8 +19,8 @@
 namespace emf {
 
 struct YeeLatticeCtorArgs {
-  runko::size_t halo_size {};
-  runko::size_t Nx {}, Ny {}, Nz {};
+  std::size_t halo_size {};
+  std::size_t Nx {}, Ny {}, Nz {};
 };
 
 struct YeeLatticeFieldsAtPoint {
@@ -35,9 +35,9 @@ struct YeeLatticeFieldsAtPoint {
 /// in the Yee Lattice.
 template<typename F>
 concept yee_lattice_fields_function =
-  std::invocable<F, runko::size_t, runko::size_t, runko::size_t> and
+  std::invocable<F, runko::index_t, runko::index_t, runko::index_t> and
   std::same_as<
-    std::invoke_result_t<F, runko::size_t, runko::size_t, runko::size_t>,
+    std::invoke_result_t<F, runko::index_t, runko::index_t, runko::index_t>,
     YeeLatticeFieldsAtPoint>;
 
 /// Yee lattice of plasma quantities in tyvi::mdgrid continers.
@@ -49,7 +49,7 @@ public:
 
   using YeeLatticeHostCopy = tyvi::mdgrid_buffer<
     std::vector<YeeLatticeFieldsAtPoint>,
-    std::extents<runko::size_t>,
+    std::extents<runko::index_t>,
     std::layout_right,
     VecGrid::grid_extents_type,
     VecGrid::grid_layout_type>;
@@ -68,8 +68,8 @@ public:
   }
 
 private:
-  runko::size_t halo_size_;
-  std::array<runko::size_t, 3> extents_wout_halo_;
+  std::size_t halo_size_;
+  std::array<std::size_t, 3> extents_wout_halo_;
 
 
   /// Electric field
@@ -119,9 +119,9 @@ private:
 public:
   explicit YeeLattice(YeeLatticeCtorArgs);
 
-  [[nodiscard]] std::array<runko::size_t, 3> extents_wout_halo() const;
-  [[nodiscard]] std::array<runko::size_t, 3> extents_with_halo() const;
-  [[nodiscard]] runko::size_t halo_size() const;
+  [[nodiscard]] std::array<std::size_t, 3> extents_wout_halo() const;
+  [[nodiscard]] std::array<std::size_t, 3> extents_with_halo() const;
+  [[nodiscard]] std::size_t halo_size() const;
 
   /// Initializes E, B and J in non-halo region.
   void set_EBJ(yee_lattice_fields_function auto&& f);
@@ -253,7 +253,7 @@ public:
 
   /// Represents a set of locations and corresponding currents.
   struct [[nodiscard]] CurrentContributions {
-    thrust::device_vector<std::array<runko::size_t, 3>> locations;
+    thrust::device_vector<std::array<runko::index_t, 3>> locations;
     thrust::device_vector<std::array<value_type, 3>> currents;
   };
 
@@ -368,7 +368,7 @@ void
 {
   const auto mds_extents =
     std::views::iota(0u, mds.rank()) |
-    std::views::transform([&](const runko::size_t i) { return mds.extent(i); });
+    std::views::transform([&](const std::size_t i) { return mds.extent(i); });
 
 
   if(not std::ranges::equal(mds_extents, extents_with_halo())) {
@@ -383,13 +383,13 @@ auto
   assert_mds_spans_whole_lattice(mds);
 
   auto oneD_dir_to_index_extent =
-    [&, this](const runko::size_t i) -> std::tuple<runko::size_t, runko::size_t> {
+    [&, this](const std::size_t i) -> std::tuple<std::size_t, std::size_t> {
     switch(dir[i]) {
-      case -1: return { 0u, halo_size_ };
+      case -1: return { 0uz, halo_size_ };
       case 0: return { halo_size_, halo_size_ + extents_wout_halo_[i] };
       case 1:
         return { halo_size_ + extents_wout_halo_[i],
-                 2u * halo_size_ + extents_wout_halo_[i] };
+                 2uz * halo_size_ + extents_wout_halo_[i] };
       default:
         throw std::logic_error { std::format("dir[{}] = {} != -1, 0 or 1", i, dir[i]) };
     }
@@ -462,9 +462,9 @@ inline auto
   assert_mds_spans_whole_lattice(mds);
 
   auto oneD_dir_to_index_extent =
-    [&, this](const runko::size_t i) -> std::tuple<runko::size_t, runko::size_t> {
+    [&, this](const std::size_t i) -> std::tuple<std::size_t, std::size_t> {
     switch(invert_dir(dir)[i]) {
-      case -1: return { halo_size_, 2u * halo_size_ };
+      case -1: return { halo_size_, 2uz * halo_size_ };
       case 0: return { halo_size_, halo_size_ + extents_wout_halo_[i] };
       case 1: return { extents_wout_halo_[i], halo_size_ + extents_wout_halo_[i] };
       default:

--- a/core/emf/yee_lattice_FDTD2.c++
+++ b/core/emf/yee_lattice_FDTD2.c++
@@ -18,7 +18,7 @@ void
 {
   /* FIXME: figure out if dt and corr from emf::FDTD2 are needed. */
   const auto h   = halo_size_;
-  const auto hp1 = h + 1uz;
+  const auto hp1 = h + 1u;
 
   const auto i_nonhalo = std::tuple { h, h + extents_wout_halo_[0] };
   const auto j_nonhalo = std::tuple { h, h + extents_wout_halo_[1] };
@@ -68,7 +68,7 @@ void
   /* FIXME: figure out if dt and corr from emf::FDTD2 are needed. */
 
   const auto h   = halo_size_;
-  const auto hm1 = static_cast<std::size_t>(halo_size_ - 1uz);
+  const auto hm1 = static_cast<runko::size_t>(halo_size_ - 1u);
 
   const auto i_nonhalo = std::tuple { h, h + extents_wout_halo_[0] };
   const auto j_nonhalo = std::tuple { h, h + extents_wout_halo_[1] };

--- a/core/emf/yee_lattice_FDTD2.c++
+++ b/core/emf/yee_lattice_FDTD2.c++
@@ -68,7 +68,7 @@ void
   /* FIXME: figure out if dt and corr from emf::FDTD2 are needed. */
 
   const auto h   = halo_size_;
-  const auto hm1 = static_cast<runko::size_t>(halo_size_ - 1u);
+  const auto hm1 = static_cast<runko::index_t>(halo_size_ - 1u);
 
   const auto i_nonhalo = std::tuple { h, h + extents_wout_halo_[0] };
   const auto j_nonhalo = std::tuple { h, h + extents_wout_halo_[1] };

--- a/core/emf/yee_lattice_current_filter_binomial2.c++
+++ b/core/emf/yee_lattice_current_filter_binomial2.c++
@@ -12,50 +12,119 @@ void
     filter_current_binomial2(w);
 }
 
+// NOTE: Here is the original 3D binomial filter implemented with a 3x nested loops
+//       over a 3D array. The C3 array is found to block CPU auto-SIMD vectorization.
+//
+//void
+//  emf::YeeLattice::filter_current_binomial2(const tyvi::mdgrid_work& w)
+//{
+//  // 3D 3-point binomial coefficients
+//  static constexpr value_type C3[3][3][3] = { { { 1. / 64., 2. / 64., 1. / 64. },
+//                                                { 2. / 64., 4. / 64., 2. / 64. },
+//                                                { 1. / 64., 2. / 64., 1. / 64. } },
+//                                              { { 2. / 64., 4. / 64., 2. / 64. },
+//                                                { 4. / 64., 8. / 64., 4. / 64. },
+//                                                { 2. / 64., 4. / 64., 2. / 64. } },
+//                                              { { 1. / 64., 2. / 64., 1. / 64. },
+//                                                { 2. / 64., 4. / 64., 2. / 64. },
+//                                                { 1. / 64., 2. / 64., 1. / 64. } } };
+//  constexpr auto C3_index_space           = tyvi::sstd::geometric_index_space<3, 3>();
+//
+//  auto filteredJ           = VecGrid(this->J_.extents());
+//  const auto e             = filteredJ.extents();
+//  const auto Nx            = e.extent(0);
+//  const auto Ny            = e.extent(1);
+//  const auto Nz            = e.extent(2);
+//  const auto filteredJ_mds = std::submdspan(
+//    filteredJ.mds(),
+//    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nx - 1uz },
+//    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Ny - 1uz },
+//    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nz - 1uz });
+//
+//
+//  const auto Jmds = this->J_.mds();
+//
+//    w.for_each_index(
+//      filteredJ_mds,
+//      [=](const auto idx, const auto tidx) {
+//        filteredJ_mds[idx][tidx] = 0;
+//
+//        for(const auto jdx: C3_index_space) {
+//          const auto i = idx[0] + jdx[0];
+//          const auto j = idx[1] + jdx[1];
+//          const auto k = idx[2] + jdx[2];
+//
+//          // operator += is broken in hip
+//          filteredJ_mds[idx][tidx] =
+//            filteredJ_mds[idx][tidx] + C3[jdx[0]][jdx[1]][jdx[2]] * Jmds[i, j, k][tidx];
+//        }
+//      })
+//    .wait();
+//
+//  this->J_ = std::move(filteredJ);
+//}
+
+
+
 void
   emf::YeeLattice::filter_current_binomial2(const tyvi::mdgrid_work& w)
 {
-  // 3D 3-point binomial coefficients
-  static constexpr value_type C3[3][3][3] = { { { 1. / 64., 2. / 64., 1. / 64. },
-                                                { 2. / 64., 4. / 64., 2. / 64. },
-                                                { 1. / 64., 2. / 64., 1. / 64. } },
-                                              { { 2. / 64., 4. / 64., 2. / 64. },
-                                                { 4. / 64., 8. / 64., 4. / 64. },
-                                                { 2. / 64., 4. / 64., 2. / 64. } },
-                                              { { 1. / 64., 2. / 64., 1. / 64. },
-                                                { 2. / 64., 4. / 64., 2. / 64. },
-                                                { 1. / 64., 2. / 64., 1. / 64. } } };
-  constexpr auto C3_index_space           = tyvi::sstd::geometric_index_space<3, 3>();
+  // 1D binomial coefficients (the 3D stencil is separable: C3[a][b][c] = B1[a]*B1[b]*B1[c])
+  static constexpr value_type B1[3] = { 0.25f, 0.5f, 0.25f };
 
+  const auto e  = this->J_.extents();
+  const auto Nx = e.extent(0);
+  const auto Ny = e.extent(1);
+  const auto Nz = e.extent(2);
+
+  const auto Jmds = this->J_.mds();
+
+  // Pass 1: convolve along z (dim 2)
+  // temp1 dims: (Nx, Ny, Nz-2) — z-dimension shrinks by 2
+  auto temp1      = VecGrid(Nx, Ny, Nz - 2uz);
+  const auto t1   = temp1.mds();
+
+  w.for_each_index(
+     t1,
+     [=](const auto idx, const auto tidx) {
+       const auto i = idx[0], j = idx[1], k = idx[2];
+       t1[idx][tidx] = B1[0] * Jmds[i, j, k    ][tidx]
+                     + B1[1] * Jmds[i, j, k + 1][tidx]
+                     + B1[2] * Jmds[i, j, k + 2][tidx];
+     })
+    .wait();
+
+  // Pass 2: convolve along y (dim 1)
+  // temp2 dims: (Nx, Ny-2, Nz-2) — y-dimension shrinks by 2
+  auto temp2      = VecGrid(Nx, Ny - 2uz, Nz - 2uz);
+  const auto t2   = temp2.mds();
+
+  w.for_each_index(
+     t2,
+     [=](const auto idx, const auto tidx) {
+       const auto i = idx[0], j = idx[1], k = idx[2];
+       t2[idx][tidx] = B1[0] * t1[i, j,     k][tidx]
+                     + B1[1] * t1[i, j + 1, k][tidx]
+                     + B1[2] * t1[i, j + 2, k][tidx];
+     })
+    .wait();
+
+  // Pass 3: convolve along x (dim 0) — write to interior of full-size output
   auto filteredJ           = VecGrid(this->J_.extents());
-  const auto e             = filteredJ.extents();
-  const auto Nx            = e.extent(0);
-  const auto Ny            = e.extent(1);
-  const auto Nz            = e.extent(2);
   const auto filteredJ_mds = std::submdspan(
     filteredJ.mds(),
     std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nx - 1uz },
     std::tuple { std::integral_constant<std::size_t, 1uz> {}, Ny - 1uz },
     std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nz - 1uz });
 
-
-  const auto Jmds = this->J_.mds();
-
-    w.for_each_index(
-      filteredJ_mds,
-      [=](const auto idx, const auto tidx) {
-        filteredJ_mds[idx][tidx] = 0;
-
-        for(const auto jdx: C3_index_space) {
-          const auto i = idx[0] + jdx[0];
-          const auto j = idx[1] + jdx[1];
-          const auto k = idx[2] + jdx[2];
-
-          // operator += is broken in hip
-          filteredJ_mds[idx][tidx] =
-            filteredJ_mds[idx][tidx] + C3[jdx[0]][jdx[1]][jdx[2]] * Jmds[i, j, k][tidx];
-        }
-      })
+  w.for_each_index(
+     filteredJ_mds,
+     [=](const auto idx, const auto tidx) {
+       const auto i = idx[0], j = idx[1], k = idx[2];
+       filteredJ_mds[idx][tidx] = B1[0] * t2[i,     j, k][tidx]
+                                + B1[1] * t2[i + 1, j, k][tidx]
+                                + B1[2] * t2[i + 2, j, k][tidx];
+     })
     .wait();
 
   this->J_ = std::move(filteredJ);

--- a/core/emf/yee_lattice_current_filter_binomial2.c++
+++ b/core/emf/yee_lattice_current_filter_binomial2.c++
@@ -5,6 +5,10 @@
 #include <tuple>
 #include <utility>
 
+// 3D single-pass binomial filter using a 3x3x3 coefficient array.
+// NOTE: The C3 array is found to block CPU auto-SIMD vectorization;
+//       prefer the separable binomial2_unrolled variant for CPU backends.
+
 void
   emf::YeeLattice::filter_current_binomial2()
 {
@@ -12,19 +16,8 @@ void
     filter_current_binomial2(w);
 }
 
-// 3D single-pass binomial filter using a 3x3x3 coefficient array.
-// NOTE: The C3 array is found to block CPU auto-SIMD vectorization;
-//       prefer the separable binomial2 variant for CPU backends.
-
 void
-  emf::YeeLattice::filter_current_binomial2_3d()
-{
-    const tyvi::mdgrid_work w{};
-    filter_current_binomial2_3d(w);
-}
-
-void
-  emf::YeeLattice::filter_current_binomial2_3d(const tyvi::mdgrid_work& w)
+  emf::YeeLattice::filter_current_binomial2(const tyvi::mdgrid_work& w)
 {
   // 3D 3-point binomial coefficients
   static constexpr value_type C3[3][3][3] = { { { 1. / 64., 2. / 64., 1. / 64. },
@@ -73,9 +66,17 @@ void
 }
 
 
+// Separable 3-pass binomial filter with manually unrolled 1D stencils.
 
 void
-  emf::YeeLattice::filter_current_binomial2(const tyvi::mdgrid_work& w)
+  emf::YeeLattice::filter_current_binomial2_unrolled()
+{
+    const tyvi::mdgrid_work w{};
+    filter_current_binomial2_unrolled(w);
+}
+
+void
+  emf::YeeLattice::filter_current_binomial2_unrolled(const tyvi::mdgrid_work& w)
 {
   // 1D binomial coefficients (the 3D stencil is separable: C3[a][b][c] = B1[a]*B1[b]*B1[c])
   static constexpr value_type B1[3] = { 0.25f, 0.5f, 0.25f };

--- a/core/emf/yee_lattice_current_filter_binomial2.c++
+++ b/core/emf/yee_lattice_current_filter_binomial2.c++
@@ -12,57 +12,65 @@ void
     filter_current_binomial2(w);
 }
 
-// NOTE: Here is the original 3D binomial filter implemented with a 3x nested loops
-//       over a 3D array. The C3 array is found to block CPU auto-SIMD vectorization.
-//
-//void
-//  emf::YeeLattice::filter_current_binomial2(const tyvi::mdgrid_work& w)
-//{
-//  // 3D 3-point binomial coefficients
-//  static constexpr value_type C3[3][3][3] = { { { 1. / 64., 2. / 64., 1. / 64. },
-//                                                { 2. / 64., 4. / 64., 2. / 64. },
-//                                                { 1. / 64., 2. / 64., 1. / 64. } },
-//                                              { { 2. / 64., 4. / 64., 2. / 64. },
-//                                                { 4. / 64., 8. / 64., 4. / 64. },
-//                                                { 2. / 64., 4. / 64., 2. / 64. } },
-//                                              { { 1. / 64., 2. / 64., 1. / 64. },
-//                                                { 2. / 64., 4. / 64., 2. / 64. },
-//                                                { 1. / 64., 2. / 64., 1. / 64. } } };
-//  constexpr auto C3_index_space           = tyvi::sstd::geometric_index_space<3, 3>();
-//
-//  auto filteredJ           = VecGrid(this->J_.extents());
-//  const auto e             = filteredJ.extents();
-//  const auto Nx            = e.extent(0);
-//  const auto Ny            = e.extent(1);
-//  const auto Nz            = e.extent(2);
-//  const auto filteredJ_mds = std::submdspan(
-//    filteredJ.mds(),
-//    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nx - 1u },
-//    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Ny - 1u },
-//    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nz - 1u });
-//
-//
-//  const auto Jmds = this->J_.mds();
-//
-//    w.for_each_index(
-//      filteredJ_mds,
-//      [=](const auto idx, const auto tidx) {
-//        filteredJ_mds[idx][tidx] = 0;
-//
-//        for(const auto jdx: C3_index_space) {
-//          const auto i = idx[0] + jdx[0];
-//          const auto j = idx[1] + jdx[1];
-//          const auto k = idx[2] + jdx[2];
-//
-//          // operator += is broken in hip
-//          filteredJ_mds[idx][tidx] =
-//            filteredJ_mds[idx][tidx] + C3[jdx[0]][jdx[1]][jdx[2]] * Jmds[i, j, k][tidx];
-//        }
-//      })
-//    .wait();
-//
-//  this->J_ = std::move(filteredJ);
-//}
+// 3D single-pass binomial filter using a 3x3x3 coefficient array.
+// NOTE: The C3 array is found to block CPU auto-SIMD vectorization;
+//       prefer the separable binomial2 variant for CPU backends.
+
+void
+  emf::YeeLattice::filter_current_binomial2_3d()
+{
+    const tyvi::mdgrid_work w{};
+    filter_current_binomial2_3d(w);
+}
+
+void
+  emf::YeeLattice::filter_current_binomial2_3d(const tyvi::mdgrid_work& w)
+{
+  // 3D 3-point binomial coefficients
+  static constexpr value_type C3[3][3][3] = { { { 1. / 64., 2. / 64., 1. / 64. },
+                                                { 2. / 64., 4. / 64., 2. / 64. },
+                                                { 1. / 64., 2. / 64., 1. / 64. } },
+                                              { { 2. / 64., 4. / 64., 2. / 64. },
+                                                { 4. / 64., 8. / 64., 4. / 64. },
+                                                { 2. / 64., 4. / 64., 2. / 64. } },
+                                              { { 1. / 64., 2. / 64., 1. / 64. },
+                                                { 2. / 64., 4. / 64., 2. / 64. },
+                                                { 1. / 64., 2. / 64., 1. / 64. } } };
+  constexpr auto C3_index_space           = tyvi::sstd::geometric_index_space<3, 3>();
+
+  auto filteredJ           = VecGrid(this->J_.extents());
+  const auto e             = filteredJ.extents();
+  const auto Nx            = e.extent(0);
+  const auto Ny            = e.extent(1);
+  const auto Nz            = e.extent(2);
+  const auto filteredJ_mds = std::submdspan(
+    filteredJ.mds(),
+    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nx - 1u },
+    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Ny - 1u },
+    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nz - 1u });
+
+
+  const auto Jmds = this->J_.mds();
+
+    w.for_each_index(
+      filteredJ_mds,
+      [=](const auto idx, const auto tidx) {
+        filteredJ_mds[idx][tidx] = 0;
+
+        for(const auto jdx: C3_index_space) {
+          const auto i = idx[0] + jdx[0];
+          const auto j = idx[1] + jdx[1];
+          const auto k = idx[2] + jdx[2];
+
+          // operator += is broken in hip
+          filteredJ_mds[idx][tidx] =
+            filteredJ_mds[idx][tidx] + C3[jdx[0]][jdx[1]][jdx[2]] * Jmds[i, j, k][tidx];
+        }
+      })
+    .wait();
+
+  this->J_ = std::move(filteredJ);
+}
 
 
 

--- a/core/emf/yee_lattice_current_filter_binomial2.c++
+++ b/core/emf/yee_lattice_current_filter_binomial2.c++
@@ -37,9 +37,9 @@ void
 //  const auto Nz            = e.extent(2);
 //  const auto filteredJ_mds = std::submdspan(
 //    filteredJ.mds(),
-//    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nx - 1uz },
-//    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Ny - 1uz },
-//    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nz - 1uz });
+//    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nx - 1u },
+//    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Ny - 1u },
+//    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nz - 1u });
 //
 //
 //  const auto Jmds = this->J_.mds();
@@ -81,7 +81,7 @@ void
 
   // Pass 1: convolve along z (dim 2)
   // temp1 dims: (Nx, Ny, Nz-2) — z-dimension shrinks by 2
-  auto temp1      = VecGrid(Nx, Ny, Nz - 2uz);
+  auto temp1      = VecGrid(Nx, Ny, Nz - 2u);
   const auto t1   = temp1.mds();
 
   w.for_each_index(
@@ -96,7 +96,7 @@ void
 
   // Pass 2: convolve along y (dim 1)
   // temp2 dims: (Nx, Ny-2, Nz-2) — y-dimension shrinks by 2
-  auto temp2      = VecGrid(Nx, Ny - 2uz, Nz - 2uz);
+  auto temp2      = VecGrid(Nx, Ny - 2u, Nz - 2u);
   const auto t2   = temp2.mds();
 
   w.for_each_index(
@@ -113,9 +113,9 @@ void
   auto filteredJ           = VecGrid(this->J_.extents());
   const auto filteredJ_mds = std::submdspan(
     filteredJ.mds(),
-    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nx - 1uz },
-    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Ny - 1uz },
-    std::tuple { std::integral_constant<std::size_t, 1uz> {}, Nz - 1uz });
+    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nx - 1u },
+    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Ny - 1u },
+    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nz - 1u });
 
   w.for_each_index(
      filteredJ_mds,

--- a/core/emf/yee_lattice_current_filter_binomial2.c++
+++ b/core/emf/yee_lattice_current_filter_binomial2.c++
@@ -45,9 +45,9 @@ void
   const auto Nz            = e.extent(2);
   const auto filteredJ_mds = std::submdspan(
     filteredJ.mds(),
-    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nx - 1u },
-    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Ny - 1u },
-    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nz - 1u });
+    std::tuple { std::integral_constant<runko::index_t, 1u> {}, Nx - 1u },
+    std::tuple { std::integral_constant<runko::index_t, 1u> {}, Ny - 1u },
+    std::tuple { std::integral_constant<runko::index_t, 1u> {}, Nz - 1u });
 
 
   const auto Jmds = this->J_.mds();
@@ -121,9 +121,9 @@ void
   auto filteredJ           = VecGrid(this->J_.extents());
   const auto filteredJ_mds = std::submdspan(
     filteredJ.mds(),
-    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nx - 1u },
-    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Ny - 1u },
-    std::tuple { std::integral_constant<runko::size_t, 1u> {}, Nz - 1u });
+    std::tuple { std::integral_constant<runko::index_t, 1u> {}, Nx - 1u },
+    std::tuple { std::integral_constant<runko::index_t, 1u> {}, Ny - 1u },
+    std::tuple { std::integral_constant<runko::index_t, 1u> {}, Nz - 1u });
 
   w.for_each_index(
      filteredJ_mds,

--- a/core/emf/yee_lattice_interpolate_linear_1st.c++
+++ b/core/emf/yee_lattice_interpolate_linear_1st.c++
@@ -111,27 +111,231 @@ YeeLattice::InterpolatedEB
                                         static_cast<runko::size_t>(j + jc),
                                         static_cast<runko::size_t>(k + kc) };
 
-         Ex_means_mds[ic, jc, kc] = mean(Emds[ii - 1, jj, kk][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[ic, jc, kc] = mean(Emds[ii, jj - 1, kk][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[ic, jc, kc] = mean(Emds[ii, jj, kk - 1][2], Emds[ii, jj, kk][2]);
+         Ex_means_mds[ic, jc, kc] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[ic, jc, kc] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[ic, jc, kc] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
 
          Bx_means_mds[ic, jc, kc] = mean(
-           Bmds[ii, jj, kk][0],
-           Bmds[ii, jj - 1, kk][0],
-           Bmds[ii, jj, kk - 1][0],
-           Bmds[ii, jj - 1, kk - 1][0]);
+           Bmds[ii  , jj  , kk  ][0],
+           Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0],
+           Bmds[ii  , jj-1, kk-1][0]);
 
          By_means_mds[ic, jc, kc] = mean(
-           Bmds[ii, jj, kk][1],
-           Bmds[ii - 1, jj, kk][1],
-           Bmds[ii, jj, kk - 1][1],
-           Bmds[ii - 1, jj, kk - 1][1]);
+           Bmds[ii  , jj  , kk  ][1],
+           Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1],
+           Bmds[ii-1, jj  , kk-1][1]);
 
          Bz_means_mds[ic, jc, kc] = mean(
-           Bmds[ii, jj, kk][2],
-           Bmds[ii - 1, jj, kk][2],
-           Bmds[ii, jj - 1, kk][2],
-           Bmds[ii - 1, jj - 1, kk][2]);
+           Bmds[ii  , jj  , kk  ][2],
+           Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2],
+           Bmds[ii-1, jj-1, kk  ][2]);
+       }
+
+       const auto delta_pos =
+         pos_in_lattice - index_in_lattice.template as<value_type>();
+
+       Eipo_mds[idx][0] = lerp3D(delta_pos.data, Ex_means_mds);
+       Eipo_mds[idx][1] = lerp3D(delta_pos.data, Ey_means_mds);
+       Eipo_mds[idx][2] = lerp3D(delta_pos.data, Ez_means_mds);
+
+       Bipo_mds[idx][0] = lerp3D(delta_pos.data, Bx_means_mds);
+       Bipo_mds[idx][1] = lerp3D(delta_pos.data, By_means_mds);
+       Bipo_mds[idx][2] = lerp3D(delta_pos.data, Bz_means_mds);
+     })
+    .wait();
+  return { std::move(Eipo), std::move(Bipo) };
+}
+
+YeeLattice::InterpolatedEB
+  YeeLattice::interpolate_EB_linear_1st_unrolled(
+    const std::array<value_type, 3> lattice_origo_coordinates,
+    const runko::VecList<value_type>& pos) const
+{
+  tyvi::mdgrid_work w {};
+  return interpolate_EB_linear_1st_unrolled(w, lattice_origo_coordinates, pos);
+}
+
+YeeLattice::InterpolatedEB
+  YeeLattice::interpolate_EB_linear_1st_unrolled(
+    const tyvi::mdgrid_work& w,
+    const std::array<value_type, 3> lattice_origo_coordinates,
+    const runko::VecList<value_type>& pos) const
+{
+  auto Eipo = runko::VecList<value_type>(pos.extents());
+  auto Bipo = runko::VecList<value_type>(pos.extents());
+
+  const auto posmds   = pos.mds();
+  const auto Eipo_mds = Eipo.mds();
+  const auto Bipo_mds = Bipo.mds();
+
+  // Note that these include the halo.
+  const auto Emds = E_.mds();
+  const auto Bmds = B_.mds();
+
+  // Fill in Eipo_mds.
+  w.for_each_index(
+     posmds,
+     [=](const auto idx) {
+       const auto pos            = toolbox::Vec3<value_type>(posmds[idx]);
+       const auto origo          = toolbox::Vec3<value_type>(lattice_origo_coordinates);
+       const auto pos_in_lattice = pos - origo;
+
+       const auto index_in_lattice = pos_in_lattice.template as<runko::size_t>();
+       const auto [i, j, k]        = index_in_lattice.data;
+
+       auto Ex_means = std::array<value_type, 8> {};
+       auto Ey_means = std::array<value_type, 8> {};
+       auto Ez_means = std::array<value_type, 8> {};
+
+       using lerp3D_extents = std::extents<runko::size_t, 2, 2, 2>;
+       auto Ex_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ex_means.data());
+       auto Ey_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ey_means.data());
+       auto Ez_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ez_means.data());
+
+       auto Bx_means = std::array<value_type, 8> {};
+       auto By_means = std::array<value_type, 8> {};
+       auto Bz_means = std::array<value_type, 8> {};
+
+       auto Bx_means_mds = std::mdspan<value_type, lerp3D_extents>(Bx_means.data());
+       auto By_means_mds = std::mdspan<value_type, lerp3D_extents>(By_means.data());
+       auto Bz_means_mds = std::mdspan<value_type, lerp3D_extents>(Bz_means.data());
+
+       static constexpr auto mean = []<typename... T>(const T... vals) {
+         const auto sum = (vals + ...);
+         return sum / static_cast<std::remove_cvref_t<decltype(sum)>>(sizeof...(vals));
+       };
+
+       // Manually unrolled 2x2x2 stencil (ic,jc,kc) in {0,1}^3
+       // (ic=0, jc=0, kc=0)
+       {
+         const auto ii = i + 0u, jj = j + 0u, kk = k + 0u;
+         Ex_means_mds[0, 0, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[0, 0, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[0, 0, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[0, 0, 0] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[0, 0, 0] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[0, 0, 0] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=0, jc=0, kc=1)
+       {
+         const auto ii = i + 0u, jj = j + 0u, kk = k + 1u;
+         Ex_means_mds[0, 0, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[0, 0, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[0, 0, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[0, 0, 1] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[0, 0, 1] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[0, 0, 1] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=0, jc=1, kc=0)
+       {
+         const auto ii = i + 0u, jj = j + 1u, kk = k + 0u;
+         Ex_means_mds[0, 1, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[0, 1, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[0, 1, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[0, 1, 0] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[0, 1, 0] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[0, 1, 0] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=0, jc=1, kc=1)
+       {
+         const auto ii = i + 0u, jj = j + 1u, kk = k + 1u;
+         Ex_means_mds[0, 1, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[0, 1, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[0, 1, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[0, 1, 1] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[0, 1, 1] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[0, 1, 1] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=1, jc=0, kc=0)
+       {
+         const auto ii = i + 1u, jj = j + 0u, kk = k + 0u;
+         Ex_means_mds[1, 0, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[1, 0, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[1, 0, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[1, 0, 0] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[1, 0, 0] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[1, 0, 0] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=1, jc=0, kc=1)
+       {
+         const auto ii = i + 1u, jj = j + 0u, kk = k + 1u;
+         Ex_means_mds[1, 0, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[1, 0, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[1, 0, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[1, 0, 1] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[1, 0, 1] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[1, 0, 1] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=1, jc=1, kc=0)
+       {
+         const auto ii = i + 1u, jj = j + 1u, kk = k + 0u;
+         Ex_means_mds[1, 1, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[1, 1, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[1, 1, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[1, 1, 0] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[1, 1, 0] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[1, 1, 0] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+       }
+       // (ic=1, jc=1, kc=1)
+       {
+         const auto ii = i + 1u, jj = j + 1u, kk = k + 1u;
+         Ex_means_mds[1, 1, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
+         Ey_means_mds[1, 1, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
+         Ez_means_mds[1, 1, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Bx_means_mds[1, 1, 1] = mean(
+           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
+           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
+         By_means_mds[1, 1, 1] = mean(
+           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[1, 1, 1] = mean(
+           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
        }
 
        const auto delta_pos =

--- a/core/emf/yee_lattice_interpolate_linear_1st.c++
+++ b/core/emf/yee_lattice_interpolate_linear_1st.c++
@@ -80,14 +80,14 @@ YeeLattice::InterpolatedEB
 
        // This should be equivelant to floor, as we assume that the particles
        // are inside the lattice, such that the subtractions are always positive.
-       const auto index_in_lattice = pos_in_lattice.template as<std::size_t>();
+       const auto index_in_lattice = pos_in_lattice.template as<runko::size_t>();
        const auto [i, j, k]        = index_in_lattice.data;
 
        auto Ex_means = std::array<value_type, 8> {};
        auto Ey_means = std::array<value_type, 8> {};
        auto Ez_means = std::array<value_type, 8> {};
 
-       using lerp3D_extents = std::extents<std::size_t, 2, 2, 2>;
+       using lerp3D_extents = std::extents<runko::size_t, 2, 2, 2>;
        auto Ex_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ex_means.data());
        auto Ey_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ey_means.data());
        auto Ez_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ez_means.data());
@@ -107,9 +107,9 @@ YeeLattice::InterpolatedEB
 
        for(const auto [ic, jc, kc]: tyvi::sstd::index_space(Ex_means_mds)) {
          const auto [ii, jj, kk] =
-           std::array<std::size_t, 3> { static_cast<std::size_t>(i + ic),
-                                        static_cast<std::size_t>(j + jc),
-                                        static_cast<std::size_t>(k + kc) };
+           std::array<runko::size_t, 3> { static_cast<runko::size_t>(i + ic),
+                                        static_cast<runko::size_t>(j + jc),
+                                        static_cast<runko::size_t>(k + kc) };
 
          Ex_means_mds[ic, jc, kc] = mean(Emds[ii - 1, jj, kk][0], Emds[ii, jj, kk][0]);
          Ey_means_mds[ic, jc, kc] = mean(Emds[ii, jj - 1, kk][1], Emds[ii, jj, kk][1]);

--- a/core/emf/yee_lattice_interpolate_linear_1st.c++
+++ b/core/emf/yee_lattice_interpolate_linear_1st.c++
@@ -111,27 +111,16 @@ YeeLattice::InterpolatedEB
                                         static_cast<runko::size_t>(j + jc),
                                         static_cast<runko::size_t>(k + kc) };
 
-         Ex_means_mds[ic, jc, kc] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[ic, jc, kc] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[ic, jc, kc] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
+         Ex_means_mds[ic,jc,kc] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,   jj,   kk  ][0]);
+         Ey_means_mds[ic,jc,kc] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,   jj,   kk  ][1]);
+         Ez_means_mds[ic,jc,kc] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,   jj,   kk  ][2]);
 
-         Bx_means_mds[ic, jc, kc] = mean(
-           Bmds[ii  , jj  , kk  ][0],
-           Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0],
-           Bmds[ii  , jj-1, kk-1][0]);
-
-         By_means_mds[ic, jc, kc] = mean(
-           Bmds[ii  , jj  , kk  ][1],
-           Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1],
-           Bmds[ii-1, jj  , kk-1][1]);
-
-         Bz_means_mds[ic, jc, kc] = mean(
-           Bmds[ii  , jj  , kk  ][2],
-           Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2],
-           Bmds[ii-1, jj-1, kk  ][2]);
+         Bx_means_mds[ic,jc,kc] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii,   jj-1, kk  ][0],
+                                       Bmds[ii  ,jj  ,kk-1][0], Bmds[ii,   jj-1, kk-1][0]);
+         By_means_mds[ic,jc,kc] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1, jj  , kk  ][1],
+                                       Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
+         Bz_means_mds[ic,jc,kc] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1, jj  , kk  ][2],
+                                       Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
        }
 
        const auto delta_pos =
@@ -212,130 +201,106 @@ YeeLattice::InterpolatedEB
        // (ic=0, jc=0, kc=0)
        {
          const auto ii = i + 0u, jj = j + 0u, kk = k + 0u;
-         Ex_means_mds[0, 0, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[0, 0, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[0, 0, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[0, 0, 0] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[0, 0, 0] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[0, 0, 0] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[0,0,0] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[0,0,0] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[0,0,0] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[0,0,0] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[0,0,0] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[0,0,0] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=0, jc=0, kc=1)
        {
          const auto ii = i + 0u, jj = j + 0u, kk = k + 1u;
-         Ex_means_mds[0, 0, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[0, 0, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[0, 0, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[0, 0, 1] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[0, 0, 1] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[0, 0, 1] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[0,0,1] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[0,0,1] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[0,0,1] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[0,0,1] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[0,0,1] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[0,0,1] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=0, jc=1, kc=0)
        {
          const auto ii = i + 0u, jj = j + 1u, kk = k + 0u;
-         Ex_means_mds[0, 1, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[0, 1, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[0, 1, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[0, 1, 0] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[0, 1, 0] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[0, 1, 0] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[0,1,0] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[0,1,0] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[0,1,0] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[0,1,0] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[0,1,0] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[0,1,0] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=0, jc=1, kc=1)
        {
          const auto ii = i + 0u, jj = j + 1u, kk = k + 1u;
-         Ex_means_mds[0, 1, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[0, 1, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[0, 1, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[0, 1, 1] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[0, 1, 1] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[0, 1, 1] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[0,1,1] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[0,1,1] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[0,1,1] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[0,1,1] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[0,1,1] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[0,1,1] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=1, jc=0, kc=0)
        {
          const auto ii = i + 1u, jj = j + 0u, kk = k + 0u;
-         Ex_means_mds[1, 0, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[1, 0, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[1, 0, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[1, 0, 0] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[1, 0, 0] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[1, 0, 0] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[1,0,0] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[1,0,0] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[1,0,0] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[1,0,0] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[1,0,0] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[1,0,0] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=1, jc=0, kc=1)
        {
          const auto ii = i + 1u, jj = j + 0u, kk = k + 1u;
-         Ex_means_mds[1, 0, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[1, 0, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[1, 0, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[1, 0, 1] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[1, 0, 1] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[1, 0, 1] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[1,0,1] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[1,0,1] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[1,0,1] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[1,0,1] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[1,0,1] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[1,0,1] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=1, jc=1, kc=0)
        {
          const auto ii = i + 1u, jj = j + 1u, kk = k + 0u;
-         Ex_means_mds[1, 1, 0] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[1, 1, 0] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[1, 1, 0] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[1, 1, 0] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[1, 1, 0] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[1, 1, 0] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[1,1,0] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[1,1,0] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[1,1,0] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[1,1,0] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[1,1,0] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[1,1,0] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
        // (ic=1, jc=1, kc=1)
        {
          const auto ii = i + 1u, jj = j + 1u, kk = k + 1u;
-         Ex_means_mds[1, 1, 1] = mean(Emds[ii-1, jj  , kk  ][0], Emds[ii, jj, kk][0]);
-         Ey_means_mds[1, 1, 1] = mean(Emds[ii  , jj-1, kk  ][1], Emds[ii, jj, kk][1]);
-         Ez_means_mds[1, 1, 1] = mean(Emds[ii  , jj  , kk-1][2], Emds[ii, jj, kk][2]);
-         Bx_means_mds[1, 1, 1] = mean(
-           Bmds[ii  , jj  , kk  ][0], Bmds[ii  , jj-1, kk  ][0],
-           Bmds[ii  , jj  , kk-1][0], Bmds[ii  , jj-1, kk-1][0]);
-         By_means_mds[1, 1, 1] = mean(
-           Bmds[ii  , jj  , kk  ][1], Bmds[ii-1, jj  , kk  ][1],
-           Bmds[ii  , jj  , kk-1][1], Bmds[ii-1, jj  , kk-1][1]);
-         Bz_means_mds[1, 1, 1] = mean(
-           Bmds[ii  , jj  , kk  ][2], Bmds[ii-1, jj  , kk  ][2],
-           Bmds[ii  , jj-1, kk  ][2], Bmds[ii-1, jj-1, kk  ][2]);
+         Ex_means_mds[1,1,1] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,  jj,  kk  ][0]);
+         Ey_means_mds[1,1,1] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,  jj,  kk  ][1]);
+         Ez_means_mds[1,1,1] = mean(Emds[ii  ,jj  ,kk-1][2], Emds[ii,  jj,  kk  ][2]);
+         Bx_means_mds[1,1,1] = mean(Bmds[ii  ,jj  ,kk  ][0], Bmds[ii  ,jj-1,kk  ][0],
+                                    Bmds[ii  ,jj  ,kk-1][0], Bmds[ii  ,jj-1,kk-1][0]);
+         By_means_mds[1,1,1] = mean(Bmds[ii  ,jj  ,kk  ][1], Bmds[ii-1,jj  ,kk  ][1],
+                                    Bmds[ii  ,jj  ,kk-1][1], Bmds[ii-1,jj  ,kk-1][1]);
+         Bz_means_mds[1,1,1] = mean(Bmds[ii  ,jj  ,kk  ][2], Bmds[ii-1,jj  ,kk  ][2],
+                                    Bmds[ii  ,jj-1,kk  ][2], Bmds[ii-1,jj-1,kk  ][2]);
        }
 
        const auto delta_pos =

--- a/core/emf/yee_lattice_interpolate_linear_1st.c++
+++ b/core/emf/yee_lattice_interpolate_linear_1st.c++
@@ -80,14 +80,14 @@ YeeLattice::InterpolatedEB
 
        // This should be equivelant to floor, as we assume that the particles
        // are inside the lattice, such that the subtractions are always positive.
-       const auto index_in_lattice = pos_in_lattice.template as<runko::size_t>();
+       const auto index_in_lattice = pos_in_lattice.template as<runko::index_t>();
        const auto [i, j, k]        = index_in_lattice.data;
 
        auto Ex_means = std::array<value_type, 8> {};
        auto Ey_means = std::array<value_type, 8> {};
        auto Ez_means = std::array<value_type, 8> {};
 
-       using lerp3D_extents = std::extents<runko::size_t, 2, 2, 2>;
+       using lerp3D_extents = std::extents<runko::index_t, 2, 2, 2>;
        auto Ex_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ex_means.data());
        auto Ey_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ey_means.data());
        auto Ez_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ez_means.data());
@@ -107,9 +107,9 @@ YeeLattice::InterpolatedEB
 
        for(const auto [ic, jc, kc]: tyvi::sstd::index_space(Ex_means_mds)) {
          const auto [ii, jj, kk] =
-           std::array<runko::size_t, 3> { static_cast<runko::size_t>(i + ic),
-                                        static_cast<runko::size_t>(j + jc),
-                                        static_cast<runko::size_t>(k + kc) };
+           std::array<runko::index_t, 3> { static_cast<runko::index_t>(i + ic),
+                                        static_cast<runko::index_t>(j + jc),
+                                        static_cast<runko::index_t>(k + kc) };
 
          Ex_means_mds[ic,jc,kc] = mean(Emds[ii-1,jj  ,kk  ][0], Emds[ii,   jj,   kk  ][0]);
          Ey_means_mds[ic,jc,kc] = mean(Emds[ii  ,jj-1,kk  ][1], Emds[ii,   jj,   kk  ][1]);
@@ -172,14 +172,14 @@ YeeLattice::InterpolatedEB
        const auto origo          = toolbox::Vec3<value_type>(lattice_origo_coordinates);
        const auto pos_in_lattice = pos - origo;
 
-       const auto index_in_lattice = pos_in_lattice.template as<runko::size_t>();
+       const auto index_in_lattice = pos_in_lattice.template as<runko::index_t>();
        const auto [i, j, k]        = index_in_lattice.data;
 
        auto Ex_means = std::array<value_type, 8> {};
        auto Ey_means = std::array<value_type, 8> {};
        auto Ez_means = std::array<value_type, 8> {};
 
-       using lerp3D_extents = std::extents<runko::size_t, 2, 2, 2>;
+       using lerp3D_extents = std::extents<runko::index_t, 2, 2, 2>;
        auto Ex_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ex_means.data());
        auto Ey_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ey_means.data());
        auto Ez_means_mds    = std::mdspan<value_type, lerp3D_extents>(Ez_means.data());

--- a/core/mdgrid_common.h
+++ b/core/mdgrid_common.h
@@ -1,9 +1,8 @@
 #pragma once
 
+#include "tools/simd_math.h"
 #include "tyvi/mdgrid.h"
 #include "tyvi/mdspan.h"
-
-#include <cstddef>
 
 namespace runko {
 
@@ -17,8 +16,8 @@ template<typename T>
 static constexpr auto vec_element =
   tyvi::mdgrid_element_descriptor<T> { .rank = 1, .dim = 3 };
 
-using list_extents = std::dextents<std::size_t, 1>;
-using grid_extents = std::dextents<std::size_t, 3>;
+using list_extents = std::dextents<runko::size_t, 1>;
+using grid_extents = std::dextents<runko::size_t, 3>;
 
 }  // namespace detail
 

--- a/core/mdgrid_common.h
+++ b/core/mdgrid_common.h
@@ -16,8 +16,8 @@ template<typename T>
 static constexpr auto vec_element =
   tyvi::mdgrid_element_descriptor<T> { .rank = 1, .dim = 3 };
 
-using list_extents = std::dextents<runko::size_t, 1>;
-using grid_extents = std::dextents<runko::size_t, 3>;
+using list_extents = std::dextents<runko::index_t, 1>;
+using grid_extents = std::dextents<runko::index_t, 3>;
 
 }  // namespace detail
 

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -30,7 +30,7 @@ ParticleContainer::ParticleContainer(const ParticleContainerArgs args) :
 {
 }
 
-std::size_t
+runko::size_t
   ParticleContainer::size() const
 {
   return pos_.extents().extent(0);
@@ -136,14 +136,14 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
 
   // subregion_index: {-1, 0, 1} x {-1, 0, 1} x {-1, 0, 1} -> {0, 1, ..., 26}
   constexpr auto subregion_index =
-    [](const int i, const int j, const int k) -> std::size_t {
-    const auto ii = static_cast<std::size_t>(i + 1);
-    const auto jj = static_cast<std::size_t>(j + 1);
-    const auto kk = static_cast<std::size_t>(k + 1);
+    [](const int i, const int j, const int k) -> runko::size_t {
+    const auto ii = static_cast<runko::size_t>(i + 1);
+    const auto jj = static_cast<runko::size_t>(j + 1);
+    const auto kk = static_cast<runko::size_t>(k + 1);
     return ii * 9 + jj * 3 + kk;
   };
 
-  constexpr auto subregion_index_to_dir = [](const std::size_t nuz) {
+  constexpr auto subregion_index_to_dir = [](const runko::size_t nuz) {
     const auto n = static_cast<int>(nuz);
     return std::array<int, 3> { (n / 9) - 1, ((n / 3) % 3) - 1, (n % 3) - 1 };
   };
@@ -152,7 +152,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   const auto vel_mds = this->vel_.mds();
 
   const auto particle_ordinal_to_subregion_index =
-    [=](const std::size_t n) -> std::size_t {
+    [=](const runko::size_t n) -> runko::size_t {
     const auto x = pos_mds[n][0];
     const auto y = pos_mds[n][1];
     const auto z = pos_mds[n][2];
@@ -168,7 +168,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   };
 
   namespace rn                       = std::ranges;
-  const auto particle_ordinals_begin = thrust::counting_iterator<std::size_t>(0uz);
+  const auto particle_ordinals_begin = thrust::counting_iterator<runko::size_t>(0u);
   const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
 
   const auto particle_subregion_indices_begin = thrust::make_transform_iterator(
@@ -177,12 +177,12 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   const auto particle_subregion_indices_end =
     rn::next(particle_subregion_indices_begin, this->size());
 
-  auto particle_subregion_indices = thrust::device_vector<std::size_t>(
+  auto particle_subregion_indices = thrust::device_vector<runko::size_t>(
     particle_subregion_indices_begin,
     particle_subregion_indices_end);
 
   auto particle_trackers =
-    thrust::device_vector<std::size_t>(particle_ordinals_begin, particle_ordinals_end);
+    thrust::device_vector<runko::size_t>(particle_ordinals_begin, particle_ordinals_end);
 
   thrust::sort_by_key(
     particle_subregion_indices.begin(),
@@ -197,7 +197,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
     .for_each_index(
       permuted_pos_mds,
       [=, p = particle_trackers.begin()](const auto idx, const auto tidx) {
-        const std::size_t i         = p[idx[0]];
+        const runko::size_t i         = p[idx[0]];
         permuted_pos_mds[idx][tidx] = pos_mds[i][tidx];
         permuted_vel_mds[idx][tidx] = vel_mds[i][tidx];
       })
@@ -217,9 +217,9 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   // particles in all of the 27 subregions.
 
   const auto present_subregion_indices =
-    thrust::host_vector<std::size_t>(particle_subregion_indices.begin(), new_end.first);
+    thrust::host_vector<runko::size_t>(particle_subregion_indices.begin(), new_end.first);
   const auto present_subregion_begins =
-    thrust::host_vector<std::size_t>(particle_trackers.begin(), new_end.second);
+    thrust::host_vector<runko::size_t>(particle_trackers.begin(), new_end.second);
 
   const auto present_subregion_ends = [&] {
     // We assumed at beginning of the function that there is at least one particle.
@@ -231,7 +231,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
 
   std::map<std::array<int, 3>, ParticleContainer::span> m {};
 
-  for(auto i = 0uz; i < present_subregion_indices.size(); ++i) {
+  for(auto i = 0u; i < present_subregion_indices.size(); ++i) {
     m.insert_or_assign(
       subregion_index_to_dir(present_subregion_indices[i]),
       ParticleContainer::span { present_subregion_begins[i],
@@ -247,13 +247,13 @@ double
   auto w = tyvi::mdgrid_work {};
 
   namespace rn                       = std::ranges;
-  const auto particle_ordinals_begin = thrust::counting_iterator<std::size_t>(0uz);
+  const auto particle_ordinals_begin = thrust::counting_iterator<runko::size_t>(0u);
   const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
 
   // Note that these are in natural units.
   const auto vel_mds = this->vel_.mds();
 
-  auto particle_ordinal_to_kinetic_energy = [=](const std::size_t n) -> double {
+  auto particle_ordinal_to_kinetic_energy = [=](const runko::size_t n) -> double {
     using Vec3   = toolbox::Vec3<value_type>;
     const auto v = Vec3(vel_mds[n]);
     const auto e = std::sqrt(value_type { 1 } + toolbox::dot(v, v)) - value_type { 1 };

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -30,7 +30,7 @@ ParticleContainer::ParticleContainer(const ParticleContainerArgs args) :
 {
 }
 
-runko::size_t
+std::size_t
   ParticleContainer::size() const
 {
   return pos_.extents().extent(0);
@@ -136,14 +136,14 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
 
   // subregion_index: {-1, 0, 1} x {-1, 0, 1} x {-1, 0, 1} -> {0, 1, ..., 26}
   constexpr auto subregion_index =
-    [](const int i, const int j, const int k) -> runko::size_t {
-    const auto ii = static_cast<runko::size_t>(i + 1);
-    const auto jj = static_cast<runko::size_t>(j + 1);
-    const auto kk = static_cast<runko::size_t>(k + 1);
+    [](const int i, const int j, const int k) -> runko::index_t {
+    const auto ii = static_cast<runko::index_t>(i + 1);
+    const auto jj = static_cast<runko::index_t>(j + 1);
+    const auto kk = static_cast<runko::index_t>(k + 1);
     return ii * 9 + jj * 3 + kk;
   };
 
-  constexpr auto subregion_index_to_dir = [](const runko::size_t nuz) {
+  constexpr auto subregion_index_to_dir = [](const runko::index_t nuz) {
     const auto n = static_cast<int>(nuz);
     return std::array<int, 3> { (n / 9) - 1, ((n / 3) % 3) - 1, (n % 3) - 1 };
   };
@@ -152,7 +152,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   const auto vel_mds = this->vel_.mds();
 
   const auto particle_ordinal_to_subregion_index =
-    [=](const runko::size_t n) -> runko::size_t {
+    [=](const runko::index_t n) -> runko::index_t {
     const auto x = pos_mds[n][0];
     const auto y = pos_mds[n][1];
     const auto z = pos_mds[n][2];
@@ -168,7 +168,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   };
 
   namespace rn                       = std::ranges;
-  const auto particle_ordinals_begin = thrust::counting_iterator<runko::size_t>(0u);
+  const auto particle_ordinals_begin = thrust::counting_iterator<runko::index_t>(0u);
   const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
 
   const auto particle_subregion_indices_begin = thrust::make_transform_iterator(
@@ -177,12 +177,12 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   const auto particle_subregion_indices_end =
     rn::next(particle_subregion_indices_begin, this->size());
 
-  auto particle_subregion_indices = thrust::device_vector<runko::size_t>(
+  auto particle_subregion_indices = thrust::device_vector<runko::index_t>(
     particle_subregion_indices_begin,
     particle_subregion_indices_end);
 
   auto particle_trackers =
-    thrust::device_vector<runko::size_t>(particle_ordinals_begin, particle_ordinals_end);
+    thrust::device_vector<runko::index_t>(particle_ordinals_begin, particle_ordinals_end);
 
   thrust::sort_by_key(
     particle_subregion_indices.begin(),
@@ -197,7 +197,7 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
     .for_each_index(
       permuted_pos_mds,
       [=, p = particle_trackers.begin()](const auto idx, const auto tidx) {
-        const runko::size_t i         = p[idx[0]];
+        const runko::index_t i         = p[idx[0]];
         permuted_pos_mds[idx][tidx] = pos_mds[i][tidx];
         permuted_vel_mds[idx][tidx] = vel_mds[i][tidx];
       })
@@ -217,9 +217,9 @@ std::pair<std::map<std::array<int, 3>, ParticleContainer::span>, ParticleContain
   // particles in all of the 27 subregions.
 
   const auto present_subregion_indices =
-    thrust::host_vector<runko::size_t>(particle_subregion_indices.begin(), new_end.first);
+    thrust::host_vector<runko::index_t>(particle_subregion_indices.begin(), new_end.first);
   const auto present_subregion_begins =
-    thrust::host_vector<runko::size_t>(particle_trackers.begin(), new_end.second);
+    thrust::host_vector<runko::index_t>(particle_trackers.begin(), new_end.second);
 
   const auto present_subregion_ends = [&] {
     // We assumed at beginning of the function that there is at least one particle.
@@ -247,13 +247,13 @@ double
   auto w = tyvi::mdgrid_work {};
 
   namespace rn                       = std::ranges;
-  const auto particle_ordinals_begin = thrust::counting_iterator<runko::size_t>(0u);
-  const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
+  const auto particle_ordinals_begin = thrust::counting_iterator<runko::index_t>(0u);
+  //const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
 
   // Note that these are in natural units.
   const auto vel_mds = this->vel_.mds();
 
-  auto particle_ordinal_to_kinetic_energy = [=](const runko::size_t n) -> double {
+  auto particle_ordinal_to_kinetic_energy = [=](const runko::index_t n) -> double {
     using Vec3   = toolbox::Vec3<value_type>;
     const auto v = Vec3(vel_mds[n]);
     const auto e = std::sqrt(value_type { 1 } + toolbox::dot(v, v)) - value_type { 1 };

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -26,7 +26,7 @@
 namespace pic {
 
 struct ParticleContainerArgs {
-  std::size_t N;
+  runko::size_t N;
   double charge, mass;
 };
 
@@ -41,8 +41,8 @@ public:
 
   /// Specifies some span of particles in ParticleContainer.
   struct span {
-    std::size_t begin { 0 }, end { 0 };
-    [[nodiscard]] constexpr std::size_t size() const { return end - begin; }
+    runko::size_t begin { 0 }, end { 0 };
+    [[nodiscard]] constexpr runko::size_t size() const { return end - begin; }
   };
 
   /// Specifies a specifc span of particles in some ParticleContainer.
@@ -52,7 +52,7 @@ public:
   struct specific_span;
 
 private:
-  using E = std::dextents<std::size_t, 1>;
+  using E = std::dextents<runko::size_t, 1>;
 
   /// Positions are in code units (i.e. x~ in x = x~ * Delta x).
   runko::VecList<value_type> pos_;
@@ -80,7 +80,7 @@ public:
   void set(const R&);
 
   /// Returns the number of particles.
-  std::size_t size() const;
+  runko::size_t size() const;
   ParticleContainerArgs args() const;
 
   std::array<std::vector<value_type>, 3> get_positions();
@@ -158,7 +158,7 @@ struct ParticleContainer::specific_span {
   ParticleContainer::span span {};
   ParticleContainer const* container { nullptr };
 
-  [[nodiscard]] constexpr std::size_t size() const { return span.size(); }
+  [[nodiscard]] constexpr runko::size_t size() const { return span.size(); }
 };
 
 template<std::convertible_to<const ParticleContainer&>... T>
@@ -178,7 +178,7 @@ inline void
   // { Nprev, Nprev + Nothers[0], ..., Nprev + Nothers[0] + ... + Nothers[-2] }
   // Note that the last sum does not include Nothers[-1].
   const auto other_begins = [&] {
-    auto temp = std::array<std::size_t, sizeof...(others)> {};
+    auto temp = std::array<runko::size_t, sizeof...(others)> {};
     std::exclusive_scan(
       Nothers.begin(),
       Nothers.end(),
@@ -190,7 +190,7 @@ inline void
   // { Nprev + Nothers[0], ..., Nprev + Nothers[0] + ... + Nothers[-1] }
   // Note that the last sum includes Nothers[-1].
   const auto other_ends = [&] {
-    auto temp = std::array<std::size_t, sizeof...(others)> {};
+    auto temp = std::array<runko::size_t, sizeof...(others)> {};
     std::inclusive_scan(
       Nothers.begin(),
       Nothers.end(),
@@ -220,7 +220,7 @@ inline void
   const auto handle_other = [&](
                               tyvi::mdgrid_work& w,
                               const ParticleContainer& other,
-                              const std::array<std::size_t, 2> where_other_goes) {
+                              const std::array<runko::size_t, 2> where_other_goes) {
     const auto other_pos_mds = other.pos_.mds();
     const auto other_vel_mds = other.vel_.mds();
 
@@ -251,7 +251,7 @@ template<std::ranges::forward_range R>
 inline void
   ParticleContainer::add_particles(const R& new_particles)
 {
-  const auto N = static_cast<std::size_t>(std::ranges::distance(new_particles));
+  const auto N = static_cast<runko::size_t>(std::ranges::distance(new_particles));
 
   auto args  = this->args();
   args.N     = N;
@@ -261,9 +261,9 @@ inline void
   const auto added_vel_smds = added.vel_.staging_mds();
 
   {
-    std::size_t i = 0;
+    runko::size_t i = 0;
     for(const auto& p: new_particles) {
-      for(const auto j: std::views::iota(0uz, 3uz)) {
+      for(const auto j: std::views::iota(0u, 3u)) {
         added_pos_smds[i][j] = p.pos[j];
         added_vel_smds[i][j] = p.vel[j];
       }
@@ -312,10 +312,10 @@ template<std::ranges::forward_range R>
      To call tyvi::when_all on all of them, we have to do a ugly hack.
      In order to do so we can only support up to Nmax spans. */
 
-  static constexpr auto Nmax = 27uz;  // atm nothing should call this with more.
+  static constexpr auto Nmax = 27u;  // atm nothing should call this with more.
   const auto Nspans          = rn::distance(spans);
 
-  if(static_cast<std::size_t>(Nspans) > Nmax) {
+  if(static_cast<runko::size_t>(Nspans) > Nmax) {
     throw std::runtime_error {
       "ParticleContainer: trying to set from too many spans."
     };
@@ -347,19 +347,19 @@ template<std::ranges::forward_range R>
   // { 0, span_sizes[0], ..., span_sizes[0] + ... + span_sizes[-2] }
   // Note that the last sum does not include span_sizes[-1].
   const auto begins = [&] {
-    auto temp = std::vector<std::size_t>(Nspans);
+    auto temp = std::vector<runko::size_t>(Nspans);
     std::exclusive_scan(
       span_sizes.begin(),
       span_sizes.end(),
       temp.begin(),
-      0uz);
+      0u);
     return temp;
   }();
 
   // { span_sizes[0], ..., span_sizes[0] + ... + span_sizes[-1] }
   // Note that the last sum includes span_sizes[-1].
   const auto ends = [&] {
-    auto temp = std::vector<std::size_t>(Nspans);
+    auto temp = std::vector<runko::size_t>(Nspans);
     std::inclusive_scan(
       span_sizes.begin(),
       span_sizes.end(),
@@ -378,7 +378,7 @@ template<std::ranges::forward_range R>
   const auto handle_span = [&](
                              tyvi::mdgrid_work& w,
                              const ParticleContainer::specific_span& span,
-                             const std::array<std::size_t, 2> location_in_this) {
+                             const std::array<runko::size_t, 2> location_in_this) {
     const auto other_pos_mds = span.container->pos_.mds();
     const auto other_vel_mds = span.container->vel_.mds();
 
@@ -396,7 +396,7 @@ template<std::ranges::forward_range R>
   };
 
   auto works = std::vector<tyvi::mdgrid_work>(begins.size());
-  for(auto i = 0uz; i < begins.size(); ++i) {
+  for(auto i = 0u; i < begins.size(); ++i) {
     handle_span(works[i], spans[i], { begins[i], ends[i] });
   }
 
@@ -445,20 +445,20 @@ inline void
   ParticleContainer::sort(pic::score_function<value_type> auto&& f)
 {
   namespace rn                       = std::ranges;
-  const auto particle_ordinals_begin = thrust::counting_iterator<std::size_t>(0uz);
+  const auto particle_ordinals_begin = thrust::counting_iterator<runko::size_t>(0u);
   const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
 
   const auto pos_mds = this->pos_.mds();
 
   const auto scores_begin = thrust::make_transform_iterator(
     particle_ordinals_begin,
-    [=, f = std::forward<decltype(f)>(f)](const std::size_t i) {
+    [=, f = std::forward<decltype(f)>(f)](const runko::size_t i) {
       return f(pos_mds[i][0], pos_mds[i][1], pos_mds[i][2]);
     });
   const auto scores_end = rn::next(scores_begin, this->size());
 
   auto trackers =
-    thrust::device_vector<std::size_t>(particle_ordinals_begin, particle_ordinals_end);
+    thrust::device_vector<runko::size_t>(particle_ordinals_begin, particle_ordinals_end);
 
   using score_t = std::invoke_result_t<decltype(f), value_type, value_type, value_type>;
   auto scores   = thrust::device_vector<score_t>(scores_begin, scores_end);
@@ -476,7 +476,7 @@ inline void
     .for_each_index(
       tmp_pos,
       [=, p = trackers.begin()](const auto idx, const auto tidx) {
-        const std::size_t i = p[idx[0]];
+        const runko::size_t i = p[idx[0]];
         pos_mds[idx][tidx]  = tmp_pos_mds[i][tidx];
         vel_mds[idx][tidx]  = tmp_vel_mds[i][tidx];
       })

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -26,7 +26,7 @@
 namespace pic {
 
 struct ParticleContainerArgs {
-  runko::size_t N;
+  std::size_t N;
   double charge, mass;
 };
 
@@ -41,8 +41,8 @@ public:
 
   /// Specifies some span of particles in ParticleContainer.
   struct span {
-    runko::size_t begin { 0 }, end { 0 };
-    [[nodiscard]] constexpr runko::size_t size() const { return end - begin; }
+    runko::index_t begin { 0 }, end { 0 };
+    [[nodiscard]] constexpr runko::index_t size() const { return end - begin; }
   };
 
   /// Specifies a specifc span of particles in some ParticleContainer.
@@ -52,7 +52,7 @@ public:
   struct specific_span;
 
 private:
-  using E = std::dextents<runko::size_t, 1>;
+  using E = std::dextents<runko::index_t, 1>;
 
   /// Positions are in code units (i.e. x~ in x = x~ * Delta x).
   runko::VecList<value_type> pos_;
@@ -80,7 +80,7 @@ public:
   void set(const R&);
 
   /// Returns the number of particles.
-  runko::size_t size() const;
+  std::size_t size() const;
   ParticleContainerArgs args() const;
 
   std::array<std::vector<value_type>, 3> get_positions();
@@ -158,7 +158,7 @@ struct ParticleContainer::specific_span {
   ParticleContainer::span span {};
   ParticleContainer const* container { nullptr };
 
-  [[nodiscard]] constexpr runko::size_t size() const { return span.size(); }
+  [[nodiscard]] constexpr runko::index_t size() const { return span.size(); }
 };
 
 template<std::convertible_to<const ParticleContainer&>... T>
@@ -178,7 +178,7 @@ inline void
   // { Nprev, Nprev + Nothers[0], ..., Nprev + Nothers[0] + ... + Nothers[-2] }
   // Note that the last sum does not include Nothers[-1].
   const auto other_begins = [&] {
-    auto temp = std::array<runko::size_t, sizeof...(others)> {};
+    auto temp = std::array<runko::index_t, sizeof...(others)> {};
     std::exclusive_scan(
       Nothers.begin(),
       Nothers.end(),
@@ -190,7 +190,7 @@ inline void
   // { Nprev + Nothers[0], ..., Nprev + Nothers[0] + ... + Nothers[-1] }
   // Note that the last sum includes Nothers[-1].
   const auto other_ends = [&] {
-    auto temp = std::array<runko::size_t, sizeof...(others)> {};
+    auto temp = std::array<runko::index_t, sizeof...(others)> {};
     std::inclusive_scan(
       Nothers.begin(),
       Nothers.end(),
@@ -220,7 +220,7 @@ inline void
   const auto handle_other = [&](
                               tyvi::mdgrid_work& w,
                               const ParticleContainer& other,
-                              const std::array<runko::size_t, 2> where_other_goes) {
+                              const std::array<runko::index_t, 2> where_other_goes) {
     const auto other_pos_mds = other.pos_.mds();
     const auto other_vel_mds = other.vel_.mds();
 
@@ -251,7 +251,7 @@ template<std::ranges::forward_range R>
 inline void
   ParticleContainer::add_particles(const R& new_particles)
 {
-  const auto N = static_cast<runko::size_t>(std::ranges::distance(new_particles));
+  const auto N = static_cast<std::size_t>(std::ranges::distance(new_particles));
 
   auto args  = this->args();
   args.N     = N;
@@ -261,7 +261,7 @@ inline void
   const auto added_vel_smds = added.vel_.staging_mds();
 
   {
-    runko::size_t i = 0;
+    runko::index_t i = 0;
     for(const auto& p: new_particles) {
       for(const auto j: std::views::iota(0u, 3u)) {
         added_pos_smds[i][j] = p.pos[j];
@@ -315,7 +315,7 @@ template<std::ranges::forward_range R>
   static constexpr auto Nmax = 27u;  // atm nothing should call this with more.
   const auto Nspans          = rn::distance(spans);
 
-  if(static_cast<runko::size_t>(Nspans) > Nmax) {
+  if(static_cast<std::size_t>(Nspans) > Nmax) {
     throw std::runtime_error {
       "ParticleContainer: trying to set from too many spans."
     };
@@ -347,19 +347,19 @@ template<std::ranges::forward_range R>
   // { 0, span_sizes[0], ..., span_sizes[0] + ... + span_sizes[-2] }
   // Note that the last sum does not include span_sizes[-1].
   const auto begins = [&] {
-    auto temp = std::vector<runko::size_t>(Nspans);
+    auto temp = std::vector<runko::index_t>(Nspans);
     std::exclusive_scan(
       span_sizes.begin(),
       span_sizes.end(),
       temp.begin(),
-      0u);
+      runko::index_t { 0 });
     return temp;
   }();
 
   // { span_sizes[0], ..., span_sizes[0] + ... + span_sizes[-1] }
   // Note that the last sum includes span_sizes[-1].
   const auto ends = [&] {
-    auto temp = std::vector<runko::size_t>(Nspans);
+    auto temp = std::vector<runko::index_t>(Nspans);
     std::inclusive_scan(
       span_sizes.begin(),
       span_sizes.end(),
@@ -378,7 +378,7 @@ template<std::ranges::forward_range R>
   const auto handle_span = [&](
                              tyvi::mdgrid_work& w,
                              const ParticleContainer::specific_span& span,
-                             const std::array<runko::size_t, 2> location_in_this) {
+                             const std::array<runko::index_t, 2> location_in_this) {
     const auto other_pos_mds = span.container->pos_.mds();
     const auto other_vel_mds = span.container->vel_.mds();
 
@@ -445,20 +445,20 @@ inline void
   ParticleContainer::sort(pic::score_function<value_type> auto&& f)
 {
   namespace rn                       = std::ranges;
-  const auto particle_ordinals_begin = thrust::counting_iterator<runko::size_t>(0u);
+  const auto particle_ordinals_begin = thrust::counting_iterator<runko::index_t>(0u);
   const auto particle_ordinals_end   = rn::next(particle_ordinals_begin, this->size());
 
   const auto pos_mds = this->pos_.mds();
 
   const auto scores_begin = thrust::make_transform_iterator(
     particle_ordinals_begin,
-    [=, f = std::forward<decltype(f)>(f)](const runko::size_t i) {
+    [=, f = std::forward<decltype(f)>(f)](const runko::index_t i) {
       return f(pos_mds[i][0], pos_mds[i][1], pos_mds[i][2]);
     });
   const auto scores_end = rn::next(scores_begin, this->size());
 
   auto trackers =
-    thrust::device_vector<runko::size_t>(particle_ordinals_begin, particle_ordinals_end);
+    thrust::device_vector<runko::index_t>(particle_ordinals_begin, particle_ordinals_end);
 
   using score_t = std::invoke_result_t<decltype(f), value_type, value_type, value_type>;
   auto scores   = thrust::device_vector<score_t>(scores_begin, scores_end);
@@ -476,7 +476,7 @@ inline void
     .for_each_index(
       tmp_pos,
       [=, p = trackers.begin()](const auto idx, const auto tidx) {
-        const runko::size_t i = p[idx[0]];
+        const runko::index_t i = p[idx[0]];
         pos_mds[idx][tidx]  = tmp_pos_mds[i][tidx];
         vel_mds[idx][tidx]  = tmp_vel_mds[i][tidx];
       })

--- a/core/pic/particle_boris.c++
+++ b/core/pic/particle_boris.c++
@@ -3,7 +3,7 @@
 #include "tools/vector.h"
 #include "tyvi/mdgrid.h"
 
-#include <cmath>
+#include "tools/simd_math.h"
 
 void
   pic::ParticleContainer::push_particles_boris(
@@ -31,7 +31,7 @@ void
         const Vec3 E0 = value_type { 0.5 } * qm * Vec3(Emds[idx]);
         const Vec3 u0 = v0 + E0;
 
-        const value_type ginv = cfl / std::sqrt(cfl * cfl + toolbox::dot(u0, u0));
+        const value_type ginv = cfl / sstd::sqrt(cfl * cfl + toolbox::dot(u0, u0));
 
         const Vec3 B0 = value_type { 0.5 } * qm * ginv * Vec3(Bmds[idx]) / cfl;
 
@@ -43,7 +43,7 @@ void
 
         for(auto i = 0uz; i < 3uz; ++i) { vel_mds[idx][i] = u2[i] / cfl; }
 
-        const value_type ginv2 = cfl / std::sqrt(cfl * cfl + toolbox::dot(u2, u2));
+        const value_type ginv2 = cfl / sstd::sqrt(cfl * cfl + toolbox::dot(u2, u2));
 
         for(auto i = 0uz; i < 3uz; ++i) {
           pos_mds[idx][i] = pos_mds[idx][i] + vel_mds[idx][i] * ginv2 * cfl;

--- a/core/pic/particle_boris.c++
+++ b/core/pic/particle_boris.c++
@@ -41,11 +41,11 @@ void
         const Vec3 u1 = f * (u0 + toolbox::cross(u0, B0));
         const Vec3 u2 = u0 + toolbox::cross(u1, B0) + E0;
 
-        for(auto i = 0uz; i < 3uz; ++i) { vel_mds[idx][i] = u2[i] / cfl; }
+        for(auto i = 0u; i < 3u; ++i) { vel_mds[idx][i] = u2[i] / cfl; }
 
         const value_type ginv2 = cfl / sstd::sqrt(cfl * cfl + toolbox::dot(u2, u2));
 
-        for(auto i = 0uz; i < 3uz; ++i) {
+        for(auto i = 0u; i < 3u; ++i) {
           pos_mds[idx][i] = pos_mds[idx][i] + vel_mds[idx][i] * ginv2 * cfl;
         }
       })

--- a/core/pic/particle_current_zigzag_1st.c++
+++ b/core/pic/particle_current_zigzag_1st.c++
@@ -89,7 +89,7 @@ emf::YeeLattice::CurrentContributions
     const auto fi2 = Vec3v(
       sstd::floor(x2(0)), sstd::floor(x2(1)), sstd::floor(x2(2)));
 
-    const auto relay = [&](const runko::size_t j) -> value_type {
+    const auto relay = [&](const runko::index_t j) -> value_type {
       const auto a  = sstd::min(fi1(j), fi2(j)) + value_type { 1 };
       const auto b1 = sstd::max(fi1(j), fi2(j));
       const auto b2 = value_type { 0.5 } * (x1(j) + x2(j));
@@ -172,12 +172,12 @@ emf::YeeLattice::CurrentContributions
     store_current(i2 + Vec3uz(1, 1, 0), Vec3v(0, 0, Fz2 * Wx2 * Wy2));
   });
 
-  auto unique_deposit_locations = thrust::device_vector<std::array<runko::size_t, 3>>(N);
+  auto unique_deposit_locations = thrust::device_vector<std::array<runko::index_t, 3>>(N);
   auto reduced_currents         = thrust::device_vector<std::array<value_type, 3>>(N);
 
   const auto uniq_dep_locs_ptr = thrust::make_transform_output_iterator(
     unique_deposit_locations.begin(),
-    [](const deposit_loc& loc) -> std::array<runko::size_t, 3> {
+    [](const deposit_loc& loc) -> std::array<runko::index_t, 3> {
       return { loc.idx(0), loc.idx(1), loc.idx(2) };
     });
 
@@ -248,7 +248,7 @@ void
         const auto fi2 = Vec3v(
           sstd::floor(x2(0)), sstd::floor(x2(1)), sstd::floor(x2(2)));
 
-        const auto relay = [&](const runko::size_t j) -> value_type {
+        const auto relay = [&](const runko::index_t j) -> value_type {
           const auto a  = sstd::min(fi1(j), fi2(j)) + value_type { 1 };
           const auto b1 = sstd::max(fi1(j), fi2(j));
           const auto b2 = value_type { 0.5 } * (x1(j) + x2(j));
@@ -274,7 +274,7 @@ void
         const auto [Wx2, Wy2, Wz2] = W2.data;
 
         const auto store_current = [&](const Vec3uz& index, const Vec3v& current) {
-          const auto si  = index.template as<runko::size_t>();
+          const auto si  = index.template as<runko::index_t>();
           auto* const Jx = &thrust::raw_reference_cast(Jmds[si.data][0]);
           auto* const Jy = &thrust::raw_reference_cast(Jmds[si.data][1]);
           auto* const Jz = &thrust::raw_reference_cast(Jmds[si.data][2]);

--- a/core/pic/particle_current_zigzag_1st.c++
+++ b/core/pic/particle_current_zigzag_1st.c++
@@ -89,7 +89,7 @@ emf::YeeLattice::CurrentContributions
     const auto fi2 = Vec3v(
       sstd::floor(x2(0)), sstd::floor(x2(1)), sstd::floor(x2(2)));
 
-    const auto relay = [&](const std::size_t j) -> value_type {
+    const auto relay = [&](const runko::size_t j) -> value_type {
       const auto a  = sstd::min(fi1(j), fi2(j)) + value_type { 1 };
       const auto b1 = sstd::max(fi1(j), fi2(j));
       const auto b2 = value_type { 0.5 } * (x1(j) + x2(j));
@@ -172,12 +172,12 @@ emf::YeeLattice::CurrentContributions
     store_current(i2 + Vec3uz(1, 1, 0), Vec3v(0, 0, Fz2 * Wx2 * Wy2));
   });
 
-  auto unique_deposit_locations = thrust::device_vector<std::array<std::size_t, 3>>(N);
+  auto unique_deposit_locations = thrust::device_vector<std::array<runko::size_t, 3>>(N);
   auto reduced_currents         = thrust::device_vector<std::array<value_type, 3>>(N);
 
   const auto uniq_dep_locs_ptr = thrust::make_transform_output_iterator(
     unique_deposit_locations.begin(),
-    [](const deposit_loc& loc) -> std::array<std::size_t, 3> {
+    [](const deposit_loc& loc) -> std::array<runko::size_t, 3> {
       return { loc.idx(0), loc.idx(1), loc.idx(2) };
     });
 
@@ -248,7 +248,7 @@ void
         const auto fi2 = Vec3v(
           sstd::floor(x2(0)), sstd::floor(x2(1)), sstd::floor(x2(2)));
 
-        const auto relay = [&](const std::size_t j) -> value_type {
+        const auto relay = [&](const runko::size_t j) -> value_type {
           const auto a  = sstd::min(fi1(j), fi2(j)) + value_type { 1 };
           const auto b1 = sstd::max(fi1(j), fi2(j));
           const auto b2 = value_type { 0.5 } * (x1(j) + x2(j));
@@ -274,7 +274,7 @@ void
         const auto [Wx2, Wy2, Wz2] = W2.data;
 
         const auto store_current = [&](const Vec3uz& index, const Vec3v& current) {
-          const auto si  = index.template as<std::size_t>();
+          const auto si  = index.template as<runko::size_t>();
           auto* const Jx = &thrust::raw_reference_cast(Jmds[si.data][0]);
           auto* const Jy = &thrust::raw_reference_cast(Jmds[si.data][1]);
           auto* const Jz = &thrust::raw_reference_cast(Jmds[si.data][2]);

--- a/core/pic/particle_current_zigzag_1st.c++
+++ b/core/pic/particle_current_zigzag_1st.c++
@@ -9,9 +9,10 @@
 #include "tools/vector.h"
 #include "tyvi/mdgrid.h"
 
-#include <algorithm>
+#include "tools/simd_math.h"
+
 #include <array>
-#include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <stdexcept>
@@ -21,23 +22,6 @@
 #include "hip/hip_runtime.h"
 #endif
 
-namespace {
-// Portability shims for min/max and atomicAdd across HIP and CPU backends.
-using std::min;
-using std::max;
-
-#if defined(TYVI_BACKEND_CPU)
-template<typename T>
-T unsafeAtomicAdd(T* addr, T val) 
-{ 
-  auto old = *addr; 
-#pragma omp atomic update
-  *addr += val; 
-  return old; 
-}
-#endif
-}  // namespace
-
 namespace pic {
 
 emf::YeeLattice::CurrentContributions
@@ -45,7 +29,7 @@ emf::YeeLattice::CurrentContributions
     const std::array<value_type, 3> lattice_origo_coordinates,
     const double cfl_) const
 {
-  using Vec3uz = toolbox::Vec3<std::size_t>;
+  using Vec3uz = toolbox::Vec3<uint32_t>;
   using Vec3v  = toolbox::Vec3<value_type>;
 
   //--------------------------------------------------
@@ -70,7 +54,7 @@ emf::YeeLattice::CurrentContributions
   };
 
   //--------------------------------------------------
-  static constexpr auto max_num_of_nodes_effected = 14uz;
+  static constexpr auto max_num_of_nodes_effected = 14u;
   const auto N = this->size() * max_num_of_nodes_effected;
 
   auto deposit_locations     = thrust::device_vector<deposit_loc>(N);
@@ -92,24 +76,25 @@ emf::YeeLattice::CurrentContributions
   w.for_each_index(pos_mds, [=](const auto idx) {
     const auto u = Vec3v(vel_mds[idx]).template as<value_type>();
     const value_type invgam =
-      value_type { 1 } / std::sqrt(value_type { 1 } + toolbox::dot(u, u));
+      value_type { 1 } / sstd::sqrt(value_type { 1 } + toolbox::dot(u, u));
 
     const auto x2 = Vec3v(pos_mds[idx]).template as<value_type>() -
                     Vec3v(lattice_origo_coordinates).template as<value_type>();
 
     const auto x1 = x2 - cfl * invgam * u;
 
-    // These are equivalent to floor assuming that x1 and x2 do not have negative
-    // values
-    const auto i1 = x1.template as<std::size_t>();
-    const auto i2 = x2.template as<std::size_t>();
+    // Float floor for relay and weight computation (pure float — no 64-bit integers)
+    const auto fi1 = Vec3v(
+      sstd::floor(x1(0)), sstd::floor(x1(1)), sstd::floor(x1(2)));
+    const auto fi2 = Vec3v(
+      sstd::floor(x2(0)), sstd::floor(x2(1)), sstd::floor(x2(2)));
 
     const auto relay = [&](const std::size_t j) -> value_type {
-      const auto a  = static_cast<value_type>(min(i1(j), i2(j)) + 1);
-      const auto b1 = static_cast<value_type>(max(i1(j), i2(j)));
+      const auto a  = sstd::min(fi1(j), fi2(j)) + value_type { 1 };
+      const auto b1 = sstd::max(fi1(j), fi2(j));
       const auto b2 = value_type { 0.5 } * (x1(j) + x2(j));
-      const auto b  = max(b1, b2);
-      return min(a, b);
+      const auto b  = sstd::max(b1, b2);
+      return sstd::min(a, b);
     };
 
     const auto x_relay = Vec3v(relay(0), relay(1), relay(2));
@@ -117,8 +102,12 @@ emf::YeeLattice::CurrentContributions
     const auto F1 = charge * (x_relay - x1);
     const auto F2 = charge * (x2 - x_relay);
 
-    const auto W1 = value_type { 0.5 } * (x1 + x_relay) - i1.template as<value_type>();
-    const auto W2 = value_type { 0.5 } * (x2 + x_relay) - i2.template as<value_type>();
+    // Integer indices only for store_current (uint32_t = 32-bit = SIMD width=4)
+    const auto i1 = fi1.template as<uint32_t>();
+    const auto i2 = fi2.template as<uint32_t>();
+
+    const auto W1 = value_type { 0.5 } * (x1 + x_relay) - fi1;
+    const auto W2 = value_type { 0.5 } * (x2 + x_relay) - fi2;
 
     const auto [Fx1, Fy1, Fz1] = F1.data;
     const auto [Fx2, Fy2, Fz2] = F2.data;
@@ -135,40 +124,40 @@ emf::YeeLattice::CurrentContributions
     store_current(
       i1,
       Vec3v(
-        Fx1 * (1.0 - Wy1) * (1.0 - Wz1),
-        Fy1 * (1.0 - Wx1) * (1.0 - Wz1),
-        Fz1 * (1.0 - Wx1) * (1.0 - Wy1)));
+        Fx1 * (1.0f - Wy1) * (1.0f - Wz1),
+        Fy1 * (1.0f - Wx1) * (1.0f - Wz1),
+        Fz1 * (1.0f - Wx1) * (1.0f - Wy1)));
 
     store_current(
       i2,
       Vec3v(
-        Fx2 * (1.0 - Wy2) * (1.0 - Wz2),
-        Fy2 * (1.0 - Wx2) * (1.0 - Wz2),
-        Fz2 * (1.0 - Wx2) * (1.0 - Wy2)));
+        Fx2 * (1.0f - Wy2) * (1.0f - Wz2),
+        Fy2 * (1.0f - Wx2) * (1.0f - Wz2),
+        Fz2 * (1.0f - Wx2) * (1.0f - Wy2)));
 
     store_current(
       i1 + Vec3uz(1, 0, 0),
-      Vec3v(0, Fy1 * Wx1 * (1.0 - Wz1), Fz1 * Wx1 * (1.0 - Wy1)));
+      Vec3v(0, Fy1 * Wx1 * (1.0f - Wz1), Fz1 * Wx1 * (1.0f - Wy1)));
 
     store_current(
       i2 + Vec3uz(1, 0, 0),
-      Vec3v(0, Fy2 * Wx2 * (1.0 - Wz2), Fz2 * Wx2 * (1.0 - Wy2)));
+      Vec3v(0, Fy2 * Wx2 * (1.0f - Wz2), Fz2 * Wx2 * (1.0f - Wy2)));
 
     store_current(
       i1 + Vec3uz(0, 1, 0),
-      Vec3v(Fx1 * Wy1 * (1.0 - Wz1), 0, Fz1 * (1.0 - Wx1) * Wy1));
+      Vec3v(Fx1 * Wy1 * (1.0f - Wz1), 0, Fz1 * (1.0f - Wx1) * Wy1));
 
     store_current(
       i2 + Vec3uz(0, 1, 0),
-      Vec3v(Fx2 * Wy2 * (1.0 - Wz2), 0, Fz2 * (1.0 - Wx2) * Wy2));
+      Vec3v(Fx2 * Wy2 * (1.0f - Wz2), 0, Fz2 * (1.0f - Wx2) * Wy2));
 
     store_current(
       i1 + Vec3uz(0, 0, 1),
-      Vec3v(Fx1 * (1.0 - Wy1) * Wz1, Fy1 * (1.0 - Wx1) * Wz1, 0));
+      Vec3v(Fx1 * (1.0f - Wy1) * Wz1, Fy1 * (1.0f - Wx1) * Wz1, 0));
 
     store_current(
       i2 + Vec3uz(0, 0, 1),
-      Vec3v(Fx2 * (1.0 - Wy2) * Wz2, Fy2 * (1.0 - Wx2) * Wz2, 0));
+      Vec3v(Fx2 * (1.0f - Wy2) * Wz2, Fy2 * (1.0f - Wx2) * Wz2, 0));
 
     store_current(i1 + Vec3uz(0, 1, 1), Vec3v(Fx1 * Wy1 * Wz1, 0, 0));
 
@@ -188,7 +177,9 @@ emf::YeeLattice::CurrentContributions
 
   const auto uniq_dep_locs_ptr = thrust::make_transform_output_iterator(
     unique_deposit_locations.begin(),
-    [](const deposit_loc& loc) { return loc.idx.data; });
+    [](const deposit_loc& loc) -> std::array<std::size_t, 3> {
+      return { loc.idx(0), loc.idx(1), loc.idx(2) };
+    });
 
   const auto reduced_currents_ptr = thrust::make_transform_output_iterator(
     reduced_currents.begin(),
@@ -230,7 +221,7 @@ void
     const std::array<value_type, 3> lattice_origo_coordinates,
     const value_type cfl) const
 {
-  using Vec3uz = toolbox::Vec3<std::size_t>;
+  using Vec3uz = toolbox::Vec3<uint32_t>;
   using Vec3v  = toolbox::Vec3<value_type>;
 
   const auto Jmds         = Jout.mds();
@@ -244,24 +235,25 @@ void
       [=](const auto idx) {
         const auto u = Vec3v(vel_mds[idx]).template as<value_type>();
         const auto invgam =
-          value_type { 1 } / std::sqrt(value_type { 1 } + toolbox::dot(u, u));
+          value_type { 1 } / sstd::sqrt(value_type { 1 } + toolbox::dot(u, u));
 
         const auto x2 = Vec3v(pos_mds[idx]).template as<value_type>() -
                         Vec3v(lattice_origo_coordinates).template as<value_type>();
 
         const auto x1 = x2 - cfl * invgam * u;
 
-        // These are equivalent to floor assuming that x1 and x2 do not have negative
-        // values.
-        const auto i1 = x1.template as<std::size_t>();
-        const auto i2 = x2.template as<std::size_t>();
+        // Float floor for relay and weight computation (pure float — no 64-bit integers)
+        const auto fi1 = Vec3v(
+          sstd::floor(x1(0)), sstd::floor(x1(1)), sstd::floor(x1(2)));
+        const auto fi2 = Vec3v(
+          sstd::floor(x2(0)), sstd::floor(x2(1)), sstd::floor(x2(2)));
 
         const auto relay = [&](const std::size_t j) -> value_type {
-          const auto a  = static_cast<value_type>(min(i1(j), i2(j)) + 1);
-          const auto b1 = static_cast<value_type>(max(i1(j), i2(j)));
+          const auto a  = sstd::min(fi1(j), fi2(j)) + value_type { 1 };
+          const auto b1 = sstd::max(fi1(j), fi2(j));
           const auto b2 = value_type { 0.5 } * (x1(j) + x2(j));
-          const auto b  = max(b1, b2);
-          return min(a, b);
+          const auto b  = sstd::max(b1, b2);
+          return sstd::min(a, b);
         };
 
         const auto x_relay = Vec3v(relay(0), relay(1), relay(2));
@@ -269,10 +261,12 @@ void
         const auto F1 = charge * (x_relay - x1);
         const auto F2 = charge * (x2 - x_relay);
 
-        const auto W1 =
-          value_type { 0.5 } * (x1 + x_relay) - i1.template as<value_type>();
-        const auto W2 =
-          value_type { 0.5 } * (x2 + x_relay) - i2.template as<value_type>();
+        // Integer indices only for store_current (uint32_t = 32-bit = SIMD width=4)
+        const auto i1 = fi1.template as<uint32_t>();
+        const auto i2 = fi2.template as<uint32_t>();
+
+        const auto W1 = value_type { 0.5 } * (x1 + x_relay) - fi1;
+        const auto W2 = value_type { 0.5 } * (x2 + x_relay) - fi2;
 
         const auto [Fx1, Fy1, Fz1] = F1.data;
         const auto [Fx2, Fy2, Fz2] = F2.data;
@@ -280,65 +274,59 @@ void
         const auto [Wx2, Wy2, Wz2] = W2.data;
 
         const auto store_current = [&](const Vec3uz& index, const Vec3v& current) {
-          auto* const Jx = &thrust::raw_reference_cast(Jmds[index.data][0]);
-          auto* const Jy = &thrust::raw_reference_cast(Jmds[index.data][1]);
-          auto* const Jz = &thrust::raw_reference_cast(Jmds[index.data][2]);
+          const auto si  = index.template as<std::size_t>();
+          auto* const Jx = &thrust::raw_reference_cast(Jmds[si.data][0]);
+          auto* const Jy = &thrust::raw_reference_cast(Jmds[si.data][1]);
+          auto* const Jz = &thrust::raw_reference_cast(Jmds[si.data][2]);
 
-          // See hip docs for these.
-          std::ignore = unsafeAtomicAdd(Jx, current[0]);
-          std::ignore = unsafeAtomicAdd(Jy, current[1]);
-          std::ignore = unsafeAtomicAdd(Jz, current[2]);
+          sstd::atomic_add(Jx, current[0]);
+          sstd::atomic_add(Jy, current[1]);
+          sstd::atomic_add(Jz, current[2]);
         };
 
-        store_current(
-          i1,
-          Vec3v(
-            Fx1 * (1.0 - Wy1) * (1.0 - Wz1),
-            Fy1 * (1.0 - Wx1) * (1.0 - Wz1),
-            Fz1 * (1.0 - Wx1) * (1.0 - Wy1)));
+        store_current(i1,                   Vec3v(Fx1*(1.0f - Wy1)*(1.0f - Wz1),
+                                                  Fy1*(1.0f - Wx1)*(1.0f - Wz1),
+                                                  Fz1*(1.0f - Wx1)*(1.0f - Wy1)));
 
-        store_current(
-          i2,
-          Vec3v(
-            Fx2 * (1.0 - Wy2) * (1.0 - Wz2),
-            Fy2 * (1.0 - Wx2) * (1.0 - Wz2),
-            Fz2 * (1.0 - Wx2) * (1.0 - Wy2)));
-
-        store_current(
-          i1 + Vec3uz(1, 0, 0),
-          Vec3v(0, Fy1 * Wx1 * (1.0 - Wz1), Fz1 * Wx1 * (1.0 - Wy1)));
-
-        store_current(
-          i2 + Vec3uz(1, 0, 0),
-          Vec3v(0, Fy2 * Wx2 * (1.0 - Wz2), Fz2 * Wx2 * (1.0 - Wy2)));
-
-        store_current(
-          i1 + Vec3uz(0, 1, 0),
-          Vec3v(Fx1 * Wy1 * (1.0 - Wz1), 0, Fz1 * (1.0 - Wx1) * Wy1));
-
-        store_current(
-          i2 + Vec3uz(0, 1, 0),
-          Vec3v(Fx2 * Wy2 * (1.0 - Wz2), 0, Fz2 * (1.0 - Wx2) * Wy2));
-
-        store_current(
-          i1 + Vec3uz(0, 0, 1),
-          Vec3v(Fx1 * (1.0 - Wy1) * Wz1, Fy1 * (1.0 - Wx1) * Wz1, 0));
-
-        store_current(
-          i2 + Vec3uz(0, 0, 1),
-          Vec3v(Fx2 * (1.0 - Wy2) * Wz2, Fy2 * (1.0 - Wx2) * Wz2, 0));
-
-        store_current(i1 + Vec3uz(0, 1, 1), Vec3v(Fx1 * Wy1 * Wz1, 0, 0));
-
-        store_current(i2 + Vec3uz(0, 1, 1), Vec3v(Fx2 * Wy2 * Wz2, 0, 0));
-
-        store_current(i1 + Vec3uz(1, 0, 1), Vec3v(0, Fy1 * Wx1 * Wz1, 0));
-
-        store_current(i2 + Vec3uz(1, 0, 1), Vec3v(0, Fy2 * Wx2 * Wz2, 0));
-
-        store_current(i1 + Vec3uz(1, 1, 0), Vec3v(0, 0, Fz1 * Wx1 * Wy1));
-
-        store_current(i2 + Vec3uz(1, 1, 0), Vec3v(0, 0, Fz2 * Wx2 * Wy2));
+        store_current(i2,                   Vec3v(Fx2*(1.0f - Wy2)*(1.0f - Wz2),
+                                                  Fy2*(1.0f - Wx2)*(1.0f - Wz2),
+                                                  Fz2*(1.0f - Wx2)*(1.0f - Wy2)));
+        store_current(i1 + Vec3uz(1, 0, 0), Vec3v(0,
+                                                  Fy1*Wx1*(1.0f - Wz1),
+                                                  Fz1*Wx1*(1.0f - Wy1)));
+        store_current(i2 + Vec3uz(1, 0, 0), Vec3v(0,
+                                                  Fy2*Wx2*(1.0f - Wz2),
+                                                  Fz2*Wx2*(1.0f - Wy2)));
+        store_current(i1 + Vec3uz(0, 1, 0), Vec3v(Fx1*Wy1*(1.0f - Wz1),
+                                                  0,
+                                                  Fz1*(1.0f - Wx1)*Wy1));
+        store_current(i2 + Vec3uz(0, 1, 0), Vec3v(Fx2*Wy2*(1.0f - Wz2),
+                                                  0,
+                                                  Fz2*(1.0f - Wx2)*Wy2));
+        store_current(i1 + Vec3uz(0, 0, 1), Vec3v(Fx1*(1.0f - Wy1)*Wz1,
+                                                  Fy1*(1.0f - Wx1)*Wz1,
+                                                  0));
+        store_current(i2 + Vec3uz(0, 0, 1), Vec3v(Fx2*(1.0f - Wy2)*Wz2,
+                                                  Fy2*(1.0f - Wx2)*Wz2,
+                                                  0));
+        store_current(i1 + Vec3uz(0, 1, 1), Vec3v(Fx1*Wy1*Wz1,
+                                                  0,
+                                                  0));
+        store_current(i2 + Vec3uz(0, 1, 1), Vec3v(Fx2*Wy2*Wz2,
+                                                  0,
+                                                  0));
+        store_current(i1 + Vec3uz(1, 0, 1), Vec3v(0,
+                                                  Fy1*Wx1*Wz1,
+                                                  0));
+        store_current(i2 + Vec3uz(1, 0, 1), Vec3v(0,
+                                                  Fy2*Wx2*Wz2,
+                                                  0));
+        store_current(i1 + Vec3uz(1, 1, 0), Vec3v(0,
+                                                  0,
+                                                  Fz1*Wx1*Wy1));
+        store_current(i2 + Vec3uz(1, 1, 0), Vec3v(0,
+                                                  0,
+                                                  Fz2*Wx2*Wy2));
       })
     .wait();
 }

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -45,7 +45,7 @@ void
       .transform(qm_tuple_to_args);
   };
 
-  for(auto i = 0uz; true; ++i) {
+  for(auto i = 0u; true; ++i) {
     const auto q_label = std::format("q{}", i);
     const auto m_label = std::format("m{}", i);
 
@@ -104,7 +104,7 @@ namespace pic {
 
 template<std::size_t D>
 Tile<D>::Tile(
-  const std::array<std::size_t, 3> tile_grid_idx,
+  const std::array<runko::size_t, 3> tile_grid_idx,
   const toolbox::ConfigParser& conf) :
   corgi::Tile<D>(),
   emf::Tile<D>(tile_grid_idx, conf),
@@ -120,21 +120,21 @@ Tile<D>::Tile(
 
 template<std::size_t D>
 std::array<std::vector<typename Tile<D>::value_type>, 3>
-  Tile<D>::get_positions(const std::size_t p)
+  Tile<D>::get_positions(const runko::size_t p)
 {
   return particle_buffs_.at(p).get_positions();
 }
 
 template<std::size_t D>
 std::array<std::vector<typename Tile<D>::value_type>, 3>
-  Tile<D>::get_velocities(const std::size_t p)
+  Tile<D>::get_velocities(const runko::size_t p)
 {
   return particle_buffs_.at(p).get_velocities();
 }
 
 template<std::size_t D>
 void
-  Tile<D>::inject_to_each_cell(const std::size_t particle_type, particle_generator pgen)
+  Tile<D>::inject_to_each_cell(const runko::size_t particle_type, particle_generator pgen)
 {
   if(this->mins == this->maxs) {
     throw std::logic_error {
@@ -159,7 +159,7 @@ void
 template<std::size_t D>
 void
   Tile<D>::inject(
-    const std::size_t particle_type,
+    const runko::size_t particle_type,
     const std::vector<runko::ParticleState>& new_particles)
 {
   particle_buffs_.at(particle_type).add_particles(new_particles);
@@ -168,7 +168,7 @@ void
 template<std::size_t D>
 void
   Tile<D>::batch_inject_to_cells(
-    const std::size_t particle_type,
+    const runko::size_t particle_type,
     batch_particle_generator pgen)
 {
 
@@ -363,22 +363,22 @@ void
 
 
 template<std::size_t D>
-std::size_t
+runko::size_t
   Tile<D>::number_of_species() const
 {
   return std::ranges::size(this->particle_buffs_);
 }
 
 template<std::size_t D>
-std::size_t
-  Tile<D>::number_of_particles(const std::size_t particle_type) const
+runko::size_t
+  Tile<D>::number_of_particles(const runko::size_t particle_type) const
 {
   return this->particle_buffs_.at(particle_type).size();
 }
 
 template<std::size_t D>
 double
-  Tile<D>::total_kinetic_energy(const std::size_t particle_type) const
+  Tile<D>::total_kinetic_energy(const runko::size_t particle_type) const
 {
   return this->particle_buffs_.at(particle_type).total_kinetic_energy();
 }

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -79,6 +79,8 @@ pic::FieldInterpolator
 {
   if(p == "linear_1st") {
     return pic::FieldInterpolator::linear_1st;
+  } else if(p == "linear_1st_unrolled") {
+    return pic::FieldInterpolator::linear_1st_unrolled;
   } else {
     const auto msg = std::format("{} is not supported field_interpolator.", p);
     throw std::runtime_error { msg };
@@ -274,6 +276,17 @@ void
 
       ipol_func = std::bind_front(
         static_cast<fptr>(&emf::YeeLattice::interpolate_EB_linear_1st),
+        std::cref(this->yee_lattice_),
+        origo_pos);
+      break;
+    }
+    case FieldInterpolator::linear_1st_unrolled: {
+      using fptr = emf::YeeLattice::InterpolatedEB (emf::YeeLattice::*)(
+        std::array<emf::YeeLattice::value_type, 3>,
+        const runko::VecList<emf::YeeLattice::value_type>&) const;
+
+      ipol_func = std::bind_front(
+        static_cast<fptr>(&emf::YeeLattice::interpolate_EB_linear_1st_unrolled),
         std::cref(this->yee_lattice_),
         origo_pos);
       break;

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -106,7 +106,7 @@ namespace pic {
 
 template<std::size_t D>
 Tile<D>::Tile(
-  const std::array<runko::size_t, 3> tile_grid_idx,
+  const std::array<std::size_t, 3> tile_grid_idx,
   const toolbox::ConfigParser& conf) :
   corgi::Tile<D>(),
   emf::Tile<D>(tile_grid_idx, conf),
@@ -122,21 +122,21 @@ Tile<D>::Tile(
 
 template<std::size_t D>
 std::array<std::vector<typename Tile<D>::value_type>, 3>
-  Tile<D>::get_positions(const runko::size_t p)
+  Tile<D>::get_positions(const std::size_t p)
 {
   return particle_buffs_.at(p).get_positions();
 }
 
 template<std::size_t D>
 std::array<std::vector<typename Tile<D>::value_type>, 3>
-  Tile<D>::get_velocities(const runko::size_t p)
+  Tile<D>::get_velocities(const std::size_t p)
 {
   return particle_buffs_.at(p).get_velocities();
 }
 
 template<std::size_t D>
 void
-  Tile<D>::inject_to_each_cell(const runko::size_t particle_type, particle_generator pgen)
+  Tile<D>::inject_to_each_cell(const std::size_t particle_type, particle_generator pgen)
 {
   if(this->mins == this->maxs) {
     throw std::logic_error {
@@ -161,7 +161,7 @@ void
 template<std::size_t D>
 void
   Tile<D>::inject(
-    const runko::size_t particle_type,
+    const std::size_t particle_type,
     const std::vector<runko::ParticleState>& new_particles)
 {
   particle_buffs_.at(particle_type).add_particles(new_particles);
@@ -170,7 +170,7 @@ void
 template<std::size_t D>
 void
   Tile<D>::batch_inject_to_cells(
-    const runko::size_t particle_type,
+    const std::size_t particle_type,
     batch_particle_generator pgen)
 {
 
@@ -376,22 +376,22 @@ void
 
 
 template<std::size_t D>
-runko::size_t
+std::size_t
   Tile<D>::number_of_species() const
 {
   return std::ranges::size(this->particle_buffs_);
 }
 
 template<std::size_t D>
-runko::size_t
-  Tile<D>::number_of_particles(const runko::size_t particle_type) const
+std::size_t
+  Tile<D>::number_of_particles(const std::size_t particle_type) const
 {
   return this->particle_buffs_.at(particle_type).size();
 }
 
 template<std::size_t D>
 double
-  Tile<D>::total_kinetic_energy(const runko::size_t particle_type) const
+  Tile<D>::total_kinetic_energy(const std::size_t particle_type) const
 {
   return this->particle_buffs_.at(particle_type).total_kinetic_energy();
 }

--- a/core/pic/tile.h
+++ b/core/pic/tile.h
@@ -25,7 +25,7 @@ namespace pic {
 namespace mpi = mpi4cpp::mpi;
 
 enum class ParticlePusher { boris };
-enum class FieldInterpolator { linear_1st };
+enum class FieldInterpolator { linear_1st, linear_1st_unrolled };
 enum class CurrentDepositer { zigzag_1st, zigzag_1st_atomic };
 
 struct ParticleStateBatch {

--- a/core/pic/tile.h
+++ b/core/pic/tile.h
@@ -46,22 +46,22 @@ class Tile : virtual public emf::Tile<D>, virtual public corgi::Tile<D> {
 
   static_assert(D == 3);
 
-  std::map<std::size_t, ParticleContainer> particle_buffs_;
+  std::map<runko::size_t, ParticleContainer> particle_buffs_;
   ParticlePusher particle_pusher_;
   FieldInterpolator field_interpolator_;
   CurrentDepositer current_depositer_;
-  std::map<std::size_t, std::size_t> amount_of_particles_to_be_send_;
-  std::map<std::size_t, std::size_t> amount_of_particles_to_be_received_;
+  std::map<runko::size_t, runko::size_t> amount_of_particles_to_be_send_;
+  std::map<runko::size_t, runko::size_t> amount_of_particles_to_be_received_;
 
   /// particle type -> (direction -> span to subregion_particle_buffs_)
-  std::map<std::size_t, std::map<std::array<int, 3>, ParticleContainer::span>>
+  std::map<runko::size_t, std::map<std::array<int, 3>, ParticleContainer::span>>
     subregion_particle_spans_;
-  std::map<std::size_t, ParticleContainer> subregion_particle_buffs_;
+  std::map<runko::size_t, ParticleContainer> subregion_particle_buffs_;
 
   void divide_particles_to_subregions();
 
   /// particle type -> {0th particles, 1st particles, ...}
-  std::map<std::size_t, std::vector<ParticleContainer::specific_span>>
+  std::map<runko::size_t, std::vector<ParticleContainer::specific_span>>
     incoming_subregion_particles_ {};
 
 public:
@@ -87,15 +87,15 @@ public:
   /// Note that particle charges and masses qx and mx are read in order: 0, 1, ...
   /// If a i:th mass and charge are missing, the search is stopped.
   explicit Tile(
-    std::array<std::size_t, 3> tile_grid_idx,
+    std::array<runko::size_t, 3> tile_grid_idx,
     const toolbox::ConfigParser& config);
 
   // Has to be explicitly declared as a work around for hipcc bug.
   // see: https://github.com/llvm/llvm-project/issues/141592
   ~Tile() = default;
 
-  std::array<std::vector<value_type>, 3> get_positions(std::size_t);
-  std::array<std::vector<value_type>, 3> get_velocities(std::size_t);
+  std::array<std::vector<value_type>, 3> get_positions(runko::size_t);
+  std::array<std::vector<value_type>, 3> get_velocities(runko::size_t);
 
 
   using particle_generator =
@@ -106,12 +106,12 @@ public:
   /// Generator is called for each cell coordinates.
   ///
   /// Particle type is assumed to be configured.
-  void inject_to_each_cell(std::size_t particle_type, particle_generator);
+  void inject_to_each_cell(runko::size_t particle_type, particle_generator);
 
   /// Inject given particles.
   ///
   /// Particle type is assumed to be configured.
-  void inject(std::size_t particle_type, const std::vector<runko::ParticleState>&);
+  void inject(runko::size_t particle_type, const std::vector<runko::ParticleState>&);
 
   using batch_array = pybind11::array_t<double>;
   using batch_particle_generator =
@@ -122,7 +122,7 @@ public:
   /// Generator is called once with all cell coordinates.
   ///
   /// Particle type is assumed to be configured.
-  void batch_inject_to_cells(std::size_t particle_type, batch_particle_generator);
+  void batch_inject_to_cells(runko::size_t particle_type, batch_particle_generator);
 
   /// Push particles updating their velocities and positions.
   void push_particles();
@@ -133,9 +133,9 @@ public:
   /// Sorts the particles in order to reduce cache misses.
   void sort_particles();
 
-  std::size_t number_of_species() const;
+  runko::size_t number_of_species() const;
 
-  std::size_t number_of_particles(std::size_t particle_type) const;
+  runko::size_t number_of_particles(runko::size_t particle_type) const;
 
   /// Returns average kinetic energy of given particle type.
   ///
@@ -143,7 +143,7 @@ public:
   /// where m is the mass corresponding to the particle type.
   ///
   /// Particle type is assumed to be configured.
-  double total_kinetic_energy(std::size_t particle_type) const;
+  double total_kinetic_energy(runko::size_t particle_type) const;
 
   std::vector<mpi4cpp::mpi::request>
     send_data(mpi4cpp::mpi::communicator& /*comm*/, int dest, int mode, int tag)

--- a/core/pic/tile.h
+++ b/core/pic/tile.h
@@ -46,22 +46,22 @@ class Tile : virtual public emf::Tile<D>, virtual public corgi::Tile<D> {
 
   static_assert(D == 3);
 
-  std::map<runko::size_t, ParticleContainer> particle_buffs_;
+  std::map<std::size_t, ParticleContainer> particle_buffs_;
   ParticlePusher particle_pusher_;
   FieldInterpolator field_interpolator_;
   CurrentDepositer current_depositer_;
-  std::map<runko::size_t, runko::size_t> amount_of_particles_to_be_send_;
-  std::map<runko::size_t, runko::size_t> amount_of_particles_to_be_received_;
+  std::map<std::size_t, std::size_t> amount_of_particles_to_be_send_;
+  std::map<std::size_t, std::size_t> amount_of_particles_to_be_received_;
 
   /// particle type -> (direction -> span to subregion_particle_buffs_)
-  std::map<runko::size_t, std::map<std::array<int, 3>, ParticleContainer::span>>
+  std::map<std::size_t, std::map<std::array<int, 3>, ParticleContainer::span>>
     subregion_particle_spans_;
-  std::map<runko::size_t, ParticleContainer> subregion_particle_buffs_;
+  std::map<std::size_t, ParticleContainer> subregion_particle_buffs_;
 
   void divide_particles_to_subregions();
 
   /// particle type -> {0th particles, 1st particles, ...}
-  std::map<runko::size_t, std::vector<ParticleContainer::specific_span>>
+  std::map<std::size_t, std::vector<ParticleContainer::specific_span>>
     incoming_subregion_particles_ {};
 
 public:
@@ -87,15 +87,15 @@ public:
   /// Note that particle charges and masses qx and mx are read in order: 0, 1, ...
   /// If a i:th mass and charge are missing, the search is stopped.
   explicit Tile(
-    std::array<runko::size_t, 3> tile_grid_idx,
+    std::array<std::size_t, 3> tile_grid_idx,
     const toolbox::ConfigParser& config);
 
   // Has to be explicitly declared as a work around for hipcc bug.
   // see: https://github.com/llvm/llvm-project/issues/141592
   ~Tile() = default;
 
-  std::array<std::vector<value_type>, 3> get_positions(runko::size_t);
-  std::array<std::vector<value_type>, 3> get_velocities(runko::size_t);
+  std::array<std::vector<value_type>, 3> get_positions(std::size_t);
+  std::array<std::vector<value_type>, 3> get_velocities(std::size_t);
 
 
   using particle_generator =
@@ -106,12 +106,12 @@ public:
   /// Generator is called for each cell coordinates.
   ///
   /// Particle type is assumed to be configured.
-  void inject_to_each_cell(runko::size_t particle_type, particle_generator);
+  void inject_to_each_cell(std::size_t particle_type, particle_generator);
 
   /// Inject given particles.
   ///
   /// Particle type is assumed to be configured.
-  void inject(runko::size_t particle_type, const std::vector<runko::ParticleState>&);
+  void inject(std::size_t particle_type, const std::vector<runko::ParticleState>&);
 
   using batch_array = pybind11::array_t<double>;
   using batch_particle_generator =
@@ -122,7 +122,7 @@ public:
   /// Generator is called once with all cell coordinates.
   ///
   /// Particle type is assumed to be configured.
-  void batch_inject_to_cells(runko::size_t particle_type, batch_particle_generator);
+  void batch_inject_to_cells(std::size_t particle_type, batch_particle_generator);
 
   /// Push particles updating their velocities and positions.
   void push_particles();
@@ -133,9 +133,9 @@ public:
   /// Sorts the particles in order to reduce cache misses.
   void sort_particles();
 
-  runko::size_t number_of_species() const;
+  std::size_t number_of_species() const;
 
-  runko::size_t number_of_particles(runko::size_t particle_type) const;
+  std::size_t number_of_particles(std::size_t particle_type) const;
 
   /// Returns average kinetic energy of given particle type.
   ///
@@ -143,7 +143,7 @@ public:
   /// where m is the mass corresponding to the particle type.
   ///
   /// Particle type is assumed to be configured.
-  double total_kinetic_energy(runko::size_t particle_type) const;
+  double total_kinetic_energy(std::size_t particle_type) const;
 
   std::vector<mpi4cpp::mpi::request>
     send_data(mpi4cpp::mpi::communicator& /*comm*/, int dest, int mode, int tag)

--- a/core/pic/tile_communication.c++
+++ b/core/pic/tile_communication.c++
@@ -13,7 +13,7 @@ constexpr int
   particle_tag(
     const int tag,
     const auto particle_ordinal,
-    const runko::size_t particles_in_total)
+    const std::size_t particles_in_total)
 {
   return static_cast<int>(particle_ordinal + particles_in_total * tag);
 }
@@ -25,7 +25,7 @@ constexpr int
   particle_data_tag(
     const int tag,
     const auto particle_ordinal,
-    const runko::size_t particles_in_total)
+    const std::size_t particles_in_total)
 {
   static constexpr auto x = static_cast<int>(data_type == particle_data_type::pos);
   return static_cast<int>(x + 2 * particle_ordinal + 2 * particles_in_total * tag);

--- a/core/pic/tile_communication.c++
+++ b/core/pic/tile_communication.c++
@@ -46,7 +46,7 @@ std::vector<mpi4cpp::mpi::request>
 
   // GPU backend requires GPU-aware MPI to pass device pointers directly;
   // CPU backend uses host memory where standard MPI works.
-#ifndef TYVI_USE_CPU_BACKEND
+#ifndef TYVI_BACKEND_CPU
   if(not toolbox::system_supports_gpu_aware_mpi()) {
     throw std::runtime_error {
       "GPU backend requires GPU-aware MPI."
@@ -110,7 +110,7 @@ std::vector<mpi4cpp::mpi::request>
     const int mode,
     const int tag)
 {
-#ifndef TYVI_USE_CPU_BACKEND
+#ifndef TYVI_BACKEND_CPU
   if(not toolbox::system_supports_gpu_aware_mpi()) {
     throw std::runtime_error {
       "GPU backend requires GPU-aware MPI."

--- a/core/pic/tile_communication.c++
+++ b/core/pic/tile_communication.c++
@@ -13,7 +13,7 @@ constexpr int
   particle_tag(
     const int tag,
     const auto particle_ordinal,
-    const std::size_t particles_in_total)
+    const runko::size_t particles_in_total)
 {
   return static_cast<int>(particle_ordinal + particles_in_total * tag);
 }
@@ -25,7 +25,7 @@ constexpr int
   particle_data_tag(
     const int tag,
     const auto particle_ordinal,
-    const std::size_t particles_in_total)
+    const runko::size_t particles_in_total)
 {
   static constexpr auto x = static_cast<int>(data_type == particle_data_type::pos);
   return static_cast<int>(x + 2 * particle_ordinal + 2 * particles_in_total * tag);

--- a/io/emf_average_field_energy_density.h
+++ b/io/emf_average_field_energy_density.h
@@ -22,7 +22,7 @@ namespace {
 void
   write_average_field_value(
     std::invocable<const emf::Tile<3>&> auto&& f,
-    const std::size_t lap,
+    const runko::size_t lap,
     const std::string& path,
     corgi::Grid<3>& grid)
 {
@@ -32,7 +32,7 @@ void
   const auto local_tile_indices = grid.get_local_tiles();
 
   const auto num_local_tiles = rn::size(local_tile_indices);
-  if(num_local_tiles == 0uz) {
+  if(num_local_tiles == 0u) {
     throw std::runtime_error {
       "write_average_field_value assumes that every rank has at least one tile."
     };
@@ -131,7 +131,7 @@ namespace emf {
 
 void
   write_average_B_energy_density(
-    const std::size_t lap,
+    const runko::size_t lap,
     const std::string path,
     corgi::Grid<3>& grid)
 {
@@ -144,7 +144,7 @@ void
 
 void
   write_average_E_energy_density(
-    const std::size_t lap,
+    const runko::size_t lap,
     const std::string path,
     corgi::Grid<3>& grid)
 {

--- a/io/emf_average_field_energy_density.h
+++ b/io/emf_average_field_energy_density.h
@@ -22,7 +22,7 @@ namespace {
 void
   write_average_field_value(
     std::invocable<const emf::Tile<3>&> auto&& f,
-    const runko::size_t lap,
+    const std::size_t lap,
     const std::string& path,
     corgi::Grid<3>& grid)
 {
@@ -131,7 +131,7 @@ namespace emf {
 
 void
   write_average_B_energy_density(
-    const runko::size_t lap,
+    const std::size_t lap,
     const std::string path,
     corgi::Grid<3>& grid)
 {
@@ -144,7 +144,7 @@ void
 
 void
   write_average_E_energy_density(
-    const runko::size_t lap,
+    const std::size_t lap,
     const std::string path,
     corgi::Grid<3>& grid)
 {

--- a/io/pic_average_kinetic_energy.h
+++ b/io/pic_average_kinetic_energy.h
@@ -18,7 +18,7 @@ namespace pic {
 
 void
   write_average_kinetic_energy(
-    const std::size_t lap,
+    const runko::size_t lap,
     const std::string path,
     corgi::Grid<3>& grid)
 {
@@ -28,7 +28,7 @@ void
   const auto local_tile_indices = grid.get_local_tiles();
 
   const auto num_local_tiles = std::ranges::size(local_tile_indices);
-  if(num_local_tiles == 0uz) {
+  if(num_local_tiles == 0u) {
     throw std::runtime_error {
       "write_average_kinetic_energy assumes that every rank has at least one tile."
     };
@@ -47,7 +47,7 @@ void
       }
     });
 
-  auto local_total_energy_n_number_of_particles = [&](const std::size_t particle_type) {
+  auto local_total_energy_n_number_of_particles = [&](const runko::size_t particle_type) {
     auto total_energies = pic_tiles | rv::transform([&](auto& tile) -> double {
                             return tile.total_kinetic_energy(particle_type);
                           });
@@ -68,7 +68,7 @@ void
 
   auto requests = std::vector<MPI_Request> {};
 
-  for(const auto n: rv::iota(0uz, num_species)) {
+  for(const auto n: rv::iota(0u, num_species)) {
     const auto [E, N]      = local_total_energy_n_number_of_particles(n);
     total_energies[n]      = E;
     number_of_particles[n] = N;
@@ -134,9 +134,9 @@ void
   if(grid.comm.rank() == 0) {
     std::fstream file { path, std::ios::out | std::ios::app };
     file << lap << ' ';
-    for(const auto n: rv::iota(0uz, num_species)) {
+    for(const auto n: rv::iota(0u, num_species)) {
       const auto e =
-        number_of_particles[n] == 0uz
+        number_of_particles[n] == 0u
           ? 0.0
           : total_energies[n] / static_cast<double>(number_of_particles[n]);
       file << e << ' ';

--- a/io/pic_average_kinetic_energy.h
+++ b/io/pic_average_kinetic_energy.h
@@ -18,7 +18,7 @@ namespace pic {
 
 void
   write_average_kinetic_energy(
-    const runko::size_t lap,
+    const std::size_t lap,
     const std::string path,
     corgi::Grid<3>& grid)
 {
@@ -47,7 +47,7 @@ void
       }
     });
 
-  auto local_total_energy_n_number_of_particles = [&](const runko::size_t particle_type) {
+  auto local_total_energy_n_number_of_particles = [&](const std::size_t particle_type) {
     auto total_energies = pic_tiles | rv::transform([&](auto& tile) -> double {
                             return tile.total_kinetic_energy(particle_type);
                           });

--- a/tests/multirank_tests/CMakeLists.txt
+++ b/tests/multirank_tests/CMakeLists.txt
@@ -3,10 +3,12 @@ function(add_python_mpi_test name no_mpi_proc)
         ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${no_mpi_proc}
         ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/test_${name}.py"
     )
+    set_tests_properties(${name} PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}"
+    )
 endfunction(add_python_mpi_test)
 
 add_python_mpi_test(testing_setup 2)
 add_python_mpi_test(emf_simulation 4)
 add_python_mpi_test(runko_simulation 2)
 add_python_mpi_test(pic_simulation 4)
-

--- a/tests/test_emf_current_filter_binomial2.py
+++ b/tests/test_emf_current_filter_binomial2.py
@@ -4,7 +4,10 @@ import numpy as np
 
 import runko
 
-class emf_current_filter_binomial2(unittest.TestCase):
+class _binomial_filter_tests:
+    """Shared test methods for binomial filter variants."""
+
+    current_filter = None  # override in subclass
 
     def setUp(self):
         self.config = runko.Configuration(None)
@@ -19,7 +22,7 @@ class emf_current_filter_binomial2(unittest.TestCase):
         self.config.zmin = 0
         self.config.cfl = 1
         self.config.field_propagator = "FDTD2"
-        self.config.current_filter = "binomial2"
+        self.config.current_filter = self.current_filter
 
         def f():
             tile_grid_idx = (0, 0, 0)
@@ -108,6 +111,13 @@ class emf_current_filter_binomial2(unittest.TestCase):
 
             between_zero_and_one = Jx[i, j, k] > 0 and Jx[i, j, k] < 1
             self.assertTrue(between_zero_and_one)
+
+
+class emf_current_filter_binomial2(_binomial_filter_tests, unittest.TestCase):
+    current_filter = "binomial2"
+
+class emf_current_filter_binomial2_3d(_binomial_filter_tests, unittest.TestCase):
+    current_filter = "binomial2_3d"
 
 
 if __name__ == "__main__":

--- a/tests/test_emf_current_filter_binomial2.py
+++ b/tests/test_emf_current_filter_binomial2.py
@@ -116,8 +116,8 @@ class _binomial_filter_tests:
 class emf_current_filter_binomial2(_binomial_filter_tests, unittest.TestCase):
     current_filter = "binomial2"
 
-class emf_current_filter_binomial2_3d(_binomial_filter_tests, unittest.TestCase):
-    current_filter = "binomial2_3d"
+class emf_current_filter_binomial2_unrolled(_binomial_filter_tests, unittest.TestCase):
+    current_filter = "binomial2_unrolled"
 
 
 if __name__ == "__main__":

--- a/tests/test_pic_particle_pusher_boris.py
+++ b/tests/test_pic_particle_pusher_boris.py
@@ -6,7 +6,7 @@ def decimal_part(x: float):
     return x - int(x)
 
 
-def make_test_tile():
+def make_test_tile(field_interpolator):
     config = runko.Configuration(None)
     config.Nx = 4
     config.Ny = 4
@@ -26,7 +26,7 @@ def make_test_tile():
     config.sigma = 40
     config.c_omp = 1
     config.particle_pusher = "boris"
-    config.field_interpolator = "linear_1st"
+    config.field_interpolator = field_interpolator
     config.current_depositer = "zigzag_1st"
 
     return config, runko.pic.threeD.Tile((3, 3, 3), config)
@@ -42,10 +42,12 @@ def in_middle_part(x, y, z, config):
     return a and b and c and d and e and f
 
 
-class pic_particle_pusher_boris(unittest.TestCase):
+class _particle_pusher_boris_tests:
+
+    field_interpolator = None  # override in subclass
 
     def test_Ex_only(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         E = lambda x, y, z: (0.1, 0, 0)
         zero = lambda x, y, z: (0, 0, 0)
@@ -89,7 +91,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_Ey_only(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         E = lambda x, y, z: (0, 0.1, 0)
         zero = lambda x, y, z: (0, 0, 0)
@@ -133,7 +135,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_Ez_only(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         E = lambda x, y, z: (0, 0, 0.1)
         zero = lambda x, y, z: (0, 0, 0)
@@ -177,7 +179,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_Bx_only(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         B = lambda x, y, z: (0.1, 0, 0)
         zero = lambda x, y, z: (0, 0, 0)
@@ -221,7 +223,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_By_only(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         B = lambda x, y, z: (0, 0.1, 0)
         zero = lambda x, y, z: (0, 0, 0)
@@ -265,7 +267,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_Bz_only(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         B = lambda x, y, z: (0, 0, 0.1)
         zero = lambda x, y, z: (0, 0, 0)
@@ -309,7 +311,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_same_E_at_different_x_has_the_same_effect(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         E = lambda x, y, z: (0, 0.1, 0.1)
         zero = lambda x, y, z: (0, 0, 0)
@@ -340,7 +342,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_same_E_at_different_y_has_the_same_effect(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         E = lambda x, y, z: (0.1, 0, 0.1)
         zero = lambda x, y, z: (0, 0, 0)
@@ -371,7 +373,7 @@ class pic_particle_pusher_boris(unittest.TestCase):
 
 
     def test_same_E_at_different_z_has_the_same_effect(self):
-        config, tile = make_test_tile()
+        config, tile = make_test_tile(self.field_interpolator)
 
         E = lambda x, y, z: (0.1, 0.1, 0)
         zero = lambda x, y, z: (0, 0, 0)
@@ -399,6 +401,13 @@ class pic_particle_pusher_boris(unittest.TestCase):
         assertSameXY()
         tile.push_particles()
         assertSameXY()
+
+
+class pic_particle_pusher_boris_linear_1st(_particle_pusher_boris_tests, unittest.TestCase):
+    field_interpolator = "linear_1st"
+
+class pic_particle_pusher_boris_linear_1st_unrolled(_particle_pusher_boris_tests, unittest.TestCase):
+    field_interpolator = "linear_1st_unrolled"
 
 
 if __name__ == "__main__":

--- a/tools/simd_math.h
+++ b/tools/simd_math.h
@@ -31,9 +31,10 @@ raw_ref(T& x) {
 // =====================================================================
 
 template<typename T>
-constexpr void
+inline void
 atomic_add(T* addr, T val) {
 #ifdef TYVI_BACKEND_CPU
+#pragma omp atomic update
     *addr += val;
 #elif defined(TYVI_BACKEND_HIP)
     ::unsafeAtomicAdd(addr, val);

--- a/tools/simd_math.h
+++ b/tools/simd_math.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cmath>
+#include <type_traits>
+
+#include "tyvi/backend.h"
+
+#ifdef TYVI_BACKEND_HIP
+#include "hip/hip_runtime.h"
+#include "thrust/memory.h"
+#endif
+
+namespace sstd {
+
+// =====================================================================
+// raw_ref — identity on CPU, thrust::raw_reference_cast on HIP
+// =====================================================================
+
+template<typename T>
+constexpr auto&
+raw_ref(T& x) {
+#ifdef TYVI_BACKEND_CPU
+    return x;
+#elif defined(TYVI_BACKEND_HIP)
+    return thrust::raw_reference_cast(x);
+#endif
+}
+
+// =====================================================================
+// atomic_add — direct += on CPU, unsafeAtomicAdd on HIP
+// =====================================================================
+
+template<typename T>
+constexpr void
+atomic_add(T* addr, T val) {
+#ifdef TYVI_BACKEND_CPU
+    *addr += val;
+#elif defined(TYVI_BACKEND_HIP)
+    ::unsafeAtomicAdd(addr, val);
+#endif
+}
+
+// =====================================================================
+// sin / cos — constexpr type-dispatched wrappers
+// =====================================================================
+
+template<typename T>
+constexpr auto
+sin(const T x) {
+    if constexpr (std::is_same_v<T, float>) {
+        return ::sinf(x);
+    } else {
+        return ::sin(x);
+    }
+}
+
+template<typename T>
+constexpr auto
+cos(const T x) {
+    if constexpr (std::is_same_v<T, float>) {
+        return ::cosf(x);
+    } else {
+        return ::cos(x);
+    }
+}
+
+// =====================================================================
+// sqrt — constexpr type-dispatched wrapper
+// =====================================================================
+
+template<typename T>
+constexpr auto
+sqrt(const T x) {
+    if constexpr (std::is_same_v<T, float>) {
+        return ::sqrtf(x);
+    } else {
+        return ::sqrt(x);
+    }
+}
+
+// =====================================================================
+// min / max — SIMD-friendly value-based min/max
+// =====================================================================
+// Using ternary instead of std::min/std::max to avoid reference
+// semantics that can inhibit auto-vectorization.
+
+template<typename T>
+constexpr auto
+min(const T a, const T b) {
+    return a < b ? a : b;
+}
+
+template<typename T>
+constexpr auto
+max(const T a, const T b) {
+    return a > b ? a : b;
+}
+
+// =====================================================================
+// abs — SIMD-friendly absolute value
+// =====================================================================
+
+template<typename T>
+constexpr auto
+abs(const T x) {
+    return x < T{ 0 } ? -x : x;
+}
+
+// =====================================================================
+// fmod — constexpr type-dispatched wrapper
+// =====================================================================
+
+template<typename T>
+constexpr auto
+fmod(const T a, const T b) {
+    if constexpr (std::is_same_v<T, float>) {
+        return ::fmodf(a, b);
+    } else {
+        return ::fmod(a, b);
+    }
+}
+
+// =====================================================================
+// floor — SIMD-friendly floor (FRINTM on ARM NEON)
+// =====================================================================
+
+template<typename T>
+constexpr auto
+floor(const T x) {
+    if constexpr (std::is_same_v<T, float>) {
+        return ::floorf(x);
+    } else {
+        return ::floor(x);
+    }
+}
+
+} // namespace sstd

--- a/tools/simd_math.h
+++ b/tools/simd_math.h
@@ -1,9 +1,19 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <type_traits>
 
 #include "tyvi/backend.h"
+
+// =====================================================================
+// runko::size_t — 32-bit index type to avoid 64-bit ↔ float promotion
+// that halves SIMD throughput (size_t 64-bit → int → double × float).
+// =====================================================================
+
+namespace runko {
+using size_t = uint32_t;
+}  // namespace runko
 
 #ifdef TYVI_BACKEND_HIP
 #include "hip/hip_runtime.h"

--- a/tools/simd_math.h
+++ b/tools/simd_math.h
@@ -7,12 +7,12 @@
 #include "tyvi/backend.h"
 
 // =====================================================================
-// runko::size_t — 32-bit index type to avoid 64-bit ↔ float promotion
+// runko::index_t — 32-bit index type to avoid 64-bit ↔ float promotion
 // that halves SIMD throughput (size_t 64-bit → int → double × float).
 // =====================================================================
 
 namespace runko {
-using size_t = uint32_t;
+using index_t = uint32_t;
 }  // namespace runko
 
 #ifdef TYVI_BACKEND_HIP

--- a/tools/vector.h
+++ b/tools/vector.h
@@ -38,13 +38,13 @@ struct VecD {
     }(std::make_index_sequence<D>());
   };
 
-  constexpr auto& operator()(const runko::size_t ind) & { return this->data[ind]; }
+  constexpr auto& operator()(const runko::index_t ind) & { return this->data[ind]; }
 
-  constexpr auto& operator()(const runko::size_t ind) const& { return this->data[ind]; }
+  constexpr auto& operator()(const runko::index_t ind) const& { return this->data[ind]; }
 
-  constexpr auto& operator[](const runko::size_t ind) & { return this->data[ind]; }
+  constexpr auto& operator[](const runko::index_t ind) & { return this->data[ind]; }
 
-  constexpr auto& operator[](const runko::size_t ind) const& { return this->data[ind]; }
+  constexpr auto& operator[](const runko::index_t ind) const& { return this->data[ind]; }
 
   constexpr VecD() = default;
 
@@ -84,7 +84,7 @@ struct VecD {
   friend std::ostream& operator<<(std::ostream& os, const VecD<T, D>& v)
   {
     os << "[";
-    for(runko::size_t i = 0; i < D; i++) os << v(i) << " ";
+    for(runko::index_t i = 0; i < D; i++) os << v(i) << " ";
     os << "]";
     return os;
   }
@@ -133,25 +133,25 @@ struct MatD {
   }
 
   /// Column major order.
-  constexpr auto& operator[](const runko::size_t i, const runko::size_t j) &
+  constexpr auto& operator[](const runko::index_t i, const runko::index_t j) &
   {
     return this->mds()[i, j];
   }
 
   /// Column major order.
-  constexpr auto& operator[](const runko::size_t i, const runko::size_t j) const&
+  constexpr auto& operator[](const runko::index_t i, const runko::index_t j) const&
   {
     return this->mds()[i, j];
   }
 
   /// Column major order.
-  constexpr auto& operator()(const runko::size_t i, const runko::size_t j) &
+  constexpr auto& operator()(const runko::index_t i, const runko::index_t j) &
   {
     return this->mds()[i, j];
   }
 
   /// Column major order.
-  constexpr auto& operator()(const runko::size_t i, const runko::size_t j) const&
+  constexpr auto& operator()(const runko::index_t i, const runko::index_t j) const&
   {
     return this->mds()[i, j];
   }
@@ -199,7 +199,7 @@ constexpr VecD<T, D>
   operator/(const VecD<T, D>& v, const T s)
 {
   VecD<T, D> ret;
-  for(runko::size_t i = 0; i < D; i++) ret(i) = v(i) / s;
+  for(runko::index_t i = 0; i < D; i++) ret(i) = v(i) / s;
   return ret;
 }
 
@@ -208,7 +208,7 @@ constexpr VecD<T, D>
   operator*(const VecD<T, D>& v, const T s)
 {
   VecD<T, D> ret;
-  for(runko::size_t i = 0; i < D; i++) ret(i) = v(i) * s;
+  for(runko::index_t i = 0; i < D; i++) ret(i) = v(i) * s;
   return ret;
 }
 
@@ -225,7 +225,7 @@ constexpr VecD<T, D>
   operator+(const VecD<T, D>& v1, const VecD<T, D>& v2)
 {
   VecD<T, D> ret;
-  for(runko::size_t i = 0; i < D; i++) ret(i) = v1(i) + v2(i);
+  for(runko::index_t i = 0; i < D; i++) ret(i) = v1(i) + v2(i);
   return ret;
 }
 
@@ -235,7 +235,7 @@ constexpr VecD<T, D>
   operator-(const VecD<T, D>& v1, const VecD<T, D>& v2)
 {
   VecD<T, D> ret;
-  for(runko::size_t i = 0; i < D; i++) ret(i) = v1(i) - v2(i);
+  for(runko::index_t i = 0; i < D; i++) ret(i) = v1(i) - v2(i);
   return ret;
 }
 
@@ -244,7 +244,7 @@ constexpr T
   dot(const VecD<T, D>& v1, const VecD<T, D>& v2)
 {
   T ret { 0 };
-  for(runko::size_t i = 0; i < D; i++) ret += v1(i) * v2(i);
+  for(runko::index_t i = 0; i < D; i++) ret += v1(i) * v2(i);
   return ret;
 }
 

--- a/tools/vector.h
+++ b/tools/vector.h
@@ -5,8 +5,9 @@
 
 #include "tyvi/mdspan.h"
 
+#include "tools/simd_math.h"
+
 #include <array>
-#include <cmath>
 #include <concepts>
 #include <iostream>
 #include <type_traits>
@@ -319,35 +320,35 @@ constexpr Mat3<T>
 
 //--------------------------------------------------
 // vector norm
-template<std::floating_point... T>
+template<arithmetic... T>
 constexpr std::common_type_t<T...>
   norm(const T... args)
 {
-  return std::sqrt(((args * args) + ...));
+  return sstd::sqrt(((args * args) + ...));
 }
 
-template<std::floating_point T, std::size_t D>
+template<arithmetic T, std::size_t D>
 constexpr T
   norm(const VecD<T, D>& v)
 {
-  return std::sqrt(dot(v, v));
+  return sstd::sqrt(dot(v, v));
 }
 
-template<std::floating_point T, std::size_t D>
+template<arithmetic T, std::size_t D>
 constexpr T
   norm2d(const VecD<T, D>& v)  // contracted norm in x y direction
 {
-  return std::sqrt(v(0) * v(0) + v(1) * v(1));
+  return sstd::sqrt(v(0) * v(0) + v(1) * v(1));
 }
 
-template<std::floating_point T, std::size_t D>
+template<arithmetic T, std::size_t D>
 constexpr T
   norm1d(const VecD<T, D>& v)  // contracted norm in x direction
 {
-  return std::abs(v(0));
+  return sstd::abs(v(0));
 }
 
-template<std::floating_point T, std::size_t D>
+template<arithmetic T, std::size_t D>
 constexpr T
   norm_minkowski(VecD<T, D>& v)
 {
@@ -359,7 +360,7 @@ constexpr T
     return ((v(I + 1) * v(I + 1)) + ...);
   }(std::make_index_sequence<D - 1>());
 
-  return std::sqrt(std::abs(-v(0) * v(0) + spatial_part));
+  return sstd::sqrt(sstd::abs(-v(0) * v(0) + spatial_part));
 }
 
 

--- a/tools/vector.h
+++ b/tools/vector.h
@@ -38,13 +38,13 @@ struct VecD {
     }(std::make_index_sequence<D>());
   };
 
-  constexpr auto& operator()(const std::size_t ind) & { return this->data[ind]; }
+  constexpr auto& operator()(const runko::size_t ind) & { return this->data[ind]; }
 
-  constexpr auto& operator()(const std::size_t ind) const& { return this->data[ind]; }
+  constexpr auto& operator()(const runko::size_t ind) const& { return this->data[ind]; }
 
-  constexpr auto& operator[](const std::size_t ind) & { return this->data[ind]; }
+  constexpr auto& operator[](const runko::size_t ind) & { return this->data[ind]; }
 
-  constexpr auto& operator[](const std::size_t ind) const& { return this->data[ind]; }
+  constexpr auto& operator[](const runko::size_t ind) const& { return this->data[ind]; }
 
   constexpr VecD() = default;
 
@@ -62,7 +62,7 @@ struct VecD {
              (MDS::rank() == 1) and (MDS::static_extent(0) == D)
   constexpr VecD(const MDS& mds)
   {
-    for(auto i = 0uz; i < D; ++i) { data[i] = mds[i]; }
+    for(auto i = 0u; i < D; ++i) { data[i] = mds[i]; }
   }
 
   template<std::convertible_to<T>... U>
@@ -84,7 +84,7 @@ struct VecD {
   friend std::ostream& operator<<(std::ostream& os, const VecD<T, D>& v)
   {
     os << "[";
-    for(size_t i = 0; i < D; i++) os << v(i) << " ";
+    for(runko::size_t i = 0; i < D; i++) os << v(i) << " ";
     os << "]";
     return os;
   }
@@ -133,25 +133,25 @@ struct MatD {
   }
 
   /// Column major order.
-  constexpr auto& operator[](const size_t i, const size_t j) &
+  constexpr auto& operator[](const runko::size_t i, const runko::size_t j) &
   {
     return this->mds()[i, j];
   }
 
   /// Column major order.
-  constexpr auto& operator[](const size_t i, const size_t j) const&
+  constexpr auto& operator[](const runko::size_t i, const runko::size_t j) const&
   {
     return this->mds()[i, j];
   }
 
   /// Column major order.
-  constexpr auto& operator()(const size_t i, const size_t j) &
+  constexpr auto& operator()(const runko::size_t i, const runko::size_t j) &
   {
     return this->mds()[i, j];
   }
 
   /// Column major order.
-  constexpr auto& operator()(const size_t i, const size_t j) const&
+  constexpr auto& operator()(const runko::size_t i, const runko::size_t j) const&
   {
     return this->mds()[i, j];
   }
@@ -173,9 +173,9 @@ struct MatD {
   {
     os << std::endl;
     os << "[";
-    for(auto i = 0uz; i < D; ++i) {
+    for(auto i = 0u; i < D; ++i) {
       os << "[ ";
-      for(auto j = 0uz; i < D - 1; ++i) { os << M(i, j) << " , "; }
+      for(auto j = 0u; i < D - 1; ++i) { os << M(i, j) << " , "; }
       os << M(i, D - 1) << "]" << "\n";
     }
     os << "]" << std::endl;
@@ -199,7 +199,7 @@ constexpr VecD<T, D>
   operator/(const VecD<T, D>& v, const T s)
 {
   VecD<T, D> ret;
-  for(size_t i = 0; i < D; i++) ret(i) = v(i) / s;
+  for(runko::size_t i = 0; i < D; i++) ret(i) = v(i) / s;
   return ret;
 }
 
@@ -208,7 +208,7 @@ constexpr VecD<T, D>
   operator*(const VecD<T, D>& v, const T s)
 {
   VecD<T, D> ret;
-  for(size_t i = 0; i < D; i++) ret(i) = v(i) * s;
+  for(runko::size_t i = 0; i < D; i++) ret(i) = v(i) * s;
   return ret;
 }
 
@@ -225,7 +225,7 @@ constexpr VecD<T, D>
   operator+(const VecD<T, D>& v1, const VecD<T, D>& v2)
 {
   VecD<T, D> ret;
-  for(size_t i = 0; i < D; i++) ret(i) = v1(i) + v2(i);
+  for(runko::size_t i = 0; i < D; i++) ret(i) = v1(i) + v2(i);
   return ret;
 }
 
@@ -235,7 +235,7 @@ constexpr VecD<T, D>
   operator-(const VecD<T, D>& v1, const VecD<T, D>& v2)
 {
   VecD<T, D> ret;
-  for(size_t i = 0; i < D; i++) ret(i) = v1(i) - v2(i);
+  for(runko::size_t i = 0; i < D; i++) ret(i) = v1(i) - v2(i);
   return ret;
 }
 
@@ -244,7 +244,7 @@ constexpr T
   dot(const VecD<T, D>& v1, const VecD<T, D>& v2)
 {
   T ret { 0 };
-  for(size_t i = 0; i < D; i++) ret += v1(i) * v2(i);
+  for(runko::size_t i = 0; i < D; i++) ret += v1(i) * v2(i);
   return ret;
 }
 


### PR DESCRIPTION
This is a patch to the CPU backend to improve the runko compute kernel performance and fix various performance bottlenecks (float vs double calculations that half the vector lane, etc.)

Implemented:
- Binomial filter: split 3D kernel into 3 separate x/y/z passes with a smaller kernel
- Boris: careful usage of single-type float/doubles via sstd:sqrt (from `tools/simd_math.h`). Produces maximal vector width (not half-lane)
- Zigzag: fix float/double inconsistency. Doubles the vector output
- Interpolator: hand-unrolled 2x2x2 inner loop variant that vectorizes fully on cpu