### PR TITLE
V5 prealloc at ctor

### DIFF
--- a/bindings/pypic.c++
+++ b/bindings/pypic.c++
@@ -127,7 +127,6 @@ void
     .def("push_particles", &pic::Tile<3>::push_particles)
     .def("deposit_current", &pic::Tile<3>::deposit_current)
     .def("sort_particles", &pic::Tile<3>::sort_particles)
-    .def("inject_dead_particles", &pic::Tile<3>::inject_dead_particles)
     .def("register_reflector_wall", &pic::Tile<3>::register_reflector_wall)
     .def("reflect_particles", &pic::Tile<3>::reflect_particles)
     .def("advance_reflector_walls", &pic::Tile<3>::advance_reflector_walls)

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -3,6 +3,7 @@
 #include "core/mdgrid_common.h"
 #include "thrust/count.h"
 #include "thrust/device_vector.h"
+#include "thrust/fill.h"
 #include "thrust/execution_policy.h"
 #include "thrust/host_vector.h"
 #include "thrust/iterator/counting_iterator.h"
@@ -30,6 +31,33 @@ ParticleContainer::ParticleContainer(const ParticleContainerArgs args) :
   charge_ { args.charge },
   mass_ { args.mass }
 {
+}
+
+void
+  ParticleContainer::prealloc_dead(const std::size_t N)
+{
+  if(this->size() != 0uz) {
+    throw std::runtime_error {
+      "ParticleContainer::prealloc_dead must be called on an empty container."
+    };
+  }
+  if(N == 0uz) { return; }
+
+  this->pos_.invalidating_resize(N);
+  this->vel_.invalidating_resize(N);
+  this->ids_.invalidating_resize(N);
+
+  // Only the id distinguishes a dead slot. Pushers, depositors, and reflectors
+  // early-return on id == dead_prtc_id, so pos_ and vel_ are never read for
+  // dead particles and are left uninitialized.
+  const auto w        = tyvi::mdgrid_work {};
+  const auto ids_span = this->ids_.span();
+  thrust::fill(
+    w.on_this(),
+    ids_span.data(),
+    ids_span.data() + ids_span.size(),
+    runko::dead_prtc_id);
+  w.wait();
 }
 
 std::size_t

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -108,6 +108,15 @@ public:
       std::span<const runko::ParticleState<value_type>>>
   inline void append(const R& spans);
 
+  /// Pre-allocate N dead-particle slots on an empty container.
+  ///
+  /// Sizes pos_/vel_/ids_ to N and tags every id with runko::dead_prtc_id.
+  /// pos_ and vel_ are left uninitialized — dead particles are identified
+  /// by their id alone and their position/velocity are never read. Must be
+  /// called on a container where size() == 0. No temporary buffer is
+  /// allocated, so peak memory during this call equals the final size.
+  void prealloc_dead(std::size_t N);
+
   /// Returns the number of particles dead or alive.
   std::size_t size() const;
   ParticleContainerArgs args() const;
@@ -252,20 +261,39 @@ inline void
     };
   }
 
-  const auto Nprev = this->size();
+  // Reuse the trailing dead tail in place when the new particles fit,
+  // to avoid the 2x peak of allocate-new + copy + swap.
+  const auto [Pnum, dead_tail] = [this] {
+    namespace rn = std::ranges;
+    const auto ordinals_begin = thrust::counting_iterator<runko::index_t>(0uz);
+    const auto ordinals_end   = rn::next(ordinals_begin, this->size());
+    const auto rev_begin      = thrust::reverse_iterator(ordinals_end);
+    const auto rev_end        = thrust::reverse_iterator(ordinals_begin);
+
+    const auto w     = tyvi::mdgrid_work {};
+    const auto Piter = thrust::find_if(
+      w.on_this(),
+      rev_begin,
+      rev_end,
+      [ids_mds = this->ids_.mds()](const auto n) {
+        return ids_mds[n][] != runko::dead_prtc_id;
+      });
+
+    const auto dt = static_cast<std::size_t>(rn::distance(rev_begin, Piter));
+    return std::pair { this->size() - dt, dt };
+  }();
+
   const auto Nothers =
     std::array { static_cast<const ParticleContainer&>(others).size()... };
 
-  // { Nprev, Nprev + Nothers[0], ..., Nprev + Nothers[0] + ... + Nothers[-2] }
-  // Note that the last sum does not include Nothers[-1].
+  // { Pnum, Pnum + Nothers[0], ..., Pnum + Nothers[0] + ... + Nothers[-2] }
   const auto other_begins = [&] {
     auto temp = std::array<std::size_t, sizeof...(others)> {};
-    std::exclusive_scan(Nothers.begin(), Nothers.end(), temp.begin(), Nprev);
+    std::exclusive_scan(Nothers.begin(), Nothers.end(), temp.begin(), Pnum);
     return temp;
   }();
 
-  // { Nprev + Nothers[0], ..., Nprev + Nothers[0] + ... + Nothers[-1] }
-  // Note that the last sum includes Nothers[-1].
+  // { Pnum + Nothers[0], ..., Pnum + Nothers[0] + ... + Nothers[-1] }
   const auto other_ends = [&] {
     auto temp = std::array<std::size_t, sizeof...(others)> {};
     std::inclusive_scan(
@@ -273,59 +301,88 @@ inline void
       Nothers.end(),
       temp.begin(),
       std::plus<> {},
-      Nprev);
+      Pnum);
     return temp;
   }();
 
-  const auto Ntotal = other_ends.back();
+  const auto Nothers_total = other_ends.back() - Pnum;
+  const auto final_size    = other_ends.back();
 
-  auto new_pos = runko::VecList<value_type>(Ntotal);
-  auto new_vel = runko::VecList<value_type>(Ntotal);
-  auto new_ids = runko::ScalarList<runko::prtc_id_type>(Ntotal);
+  // Parallel copy of src[0, N) into (tgt_pos, tgt_vel, tgt_ids)[tgt_range],
+  // where N = tgt_range[1] - tgt_range[0]. Used three times below: fast path
+  // (src=other, tgt=*this), alive-prefix in slow path (src=*this, tgt=new),
+  // and slow-path other-handling (src=other, tgt=new).
+  const auto copy_particles_into = [](
+                                     tyvi::mdgrid_work& w,
+                                     auto tgt_pos,
+                                     auto tgt_vel,
+                                     auto tgt_ids,
+                                     const ParticleContainer& src,
+                                     const std::array<std::size_t, 2> tgt_range) {
+    const auto tgt_pos_sub = std::submdspan(tgt_pos, tgt_range);
+    const auto tgt_vel_sub = std::submdspan(tgt_vel, tgt_range);
+    const auto tgt_ids_sub = std::submdspan(tgt_ids, tgt_range);
+    const auto src_pos     = src.pos_.mds();
+    const auto src_vel     = src.vel_.mds();
+    const auto src_ids     = src.ids_.mds();
+
+    w.for_each_index(tgt_pos_sub, [=](const auto idx, const auto tidx) {
+      tgt_pos_sub[idx][tidx] = src_pos[idx][tidx];
+      tgt_vel_sub[idx][tidx] = src_vel[idx][tidx];
+    });
+    w.for_each_index(tgt_ids_sub, [=](const auto idx) {
+      tgt_ids_sub[idx][] = src_ids[idx][];
+    });
+  };
+
+  if(Nothers_total <= dead_tail) {
+    // Fast path: writes into existing dead slots in place. No allocation.
+    const auto pos_mds = this->pos_.mds();
+    const auto vel_mds = this->vel_.mds();
+    const auto ids_mds = this->ids_.mds();
+
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      auto other_works = std::array { (std::ignore = I, tyvi::mdgrid_work {})... };
+      (copy_particles_into(
+         other_works[I],
+         pos_mds,
+         vel_mds,
+         ids_mds,
+         others,
+         { other_begins[I], other_ends[I] }),
+       ...);
+      tyvi::when_all(other_works[I]...);
+      other_works.front().wait();
+    }(std::make_index_sequence<sizeof...(others)>());
+    return;
+  }
+
+  // Slow path: grow to final_size, preserving only the alive prefix.
+  auto new_pos = runko::VecList<value_type>(final_size);
+  auto new_vel = runko::VecList<value_type>(final_size);
+  auto new_ids = runko::ScalarList<runko::prtc_id_type>(final_size);
 
   const auto new_pos_mds = new_pos.mds();
   const auto new_vel_mds = new_vel.mds();
   const auto new_ids_mds = new_ids.mds();
 
-  const auto prev_pos_mds = this->pos_.mds();
-  const auto prev_vel_mds = this->vel_.mds();
-  const auto prev_ids_mds = this->ids_.mds();
-
   auto wA = tyvi::mdgrid_work {};
-  wA.for_each_index(prev_pos_mds, [=](const auto idx, const auto tidx) {
-    new_pos_mds[idx][tidx] = prev_pos_mds[idx][tidx];
-    new_vel_mds[idx][tidx] = prev_vel_mds[idx][tidx];
-  });
-  wA.for_each_index(prev_ids_mds, [=](const auto idx) {
-    new_ids_mds[idx][] = prev_ids_mds[idx][];
-  });
-
-  const auto handle_other = [&](
-                              tyvi::mdgrid_work& w,
-                              const ParticleContainer& other,
-                              const std::array<std::size_t, 2> where_other_goes) {
-    const auto other_pos_mds = other.pos_.mds();
-    const auto other_vel_mds = other.vel_.mds();
-    const auto other_ids_mds = other.ids_.mds();
-
-    const auto other_in_new_pos_mds = std::submdspan(new_pos_mds, where_other_goes);
-    const auto other_in_new_vel_mds = std::submdspan(new_vel_mds, where_other_goes);
-    const auto other_in_new_ids_mds = std::submdspan(new_ids_mds, where_other_goes);
-
-    w.for_each_index(other_in_new_pos_mds, [=](const auto idx, const auto tidx) {
-      other_in_new_pos_mds[idx][tidx] = other_pos_mds[idx][tidx];
-      other_in_new_vel_mds[idx][tidx] = other_vel_mds[idx][tidx];
-    });
-
-    w.for_each_index(other_in_new_ids_mds, [=](const auto idx) {
-      other_in_new_ids_mds[idx][] = other_ids_mds[idx][];
-    });
-  };
+  if(Pnum > 0uz) {
+    copy_particles_into(
+      wA, new_pos_mds, new_vel_mds, new_ids_mds, *this, { 0uz, Pnum });
+  }
 
   // Ugly syntax until C++26.
   [&]<std::size_t... I>(std::index_sequence<I...>) {
     auto other_works = std::array { (std::ignore = I, tyvi::mdgrid_work {})... };
-    (handle_other(other_works[I], others, { other_begins[I], other_ends[I] }), ...);
+    (copy_particles_into(
+       other_works[I],
+       new_pos_mds,
+       new_vel_mds,
+       new_ids_mds,
+       others,
+       { other_begins[I], other_ends[I] }),
+     ...);
     tyvi::when_all(wA, other_works[I]...);
     wA.wait();
   }(std::make_index_sequence<sizeof...(others)>());

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -46,17 +46,22 @@ void
       .transform(qm_tuple_to_args);
   };
 
+  const auto prealloc_per_species =
+    conf.get<std::size_t>("prealloc_per_species").value_or(0uz);
+
   for(auto i = 0uz; true; ++i) {
     const auto q_label = std::format("q{}", i);
     const auto m_label = std::format("m{}", i);
 
     if(const auto pcontainer_args = make_opt_args(q_label, m_label)) {
+      auto container = pic::ParticleContainer { pcontainer_args.value() };
+      if(prealloc_per_species > 0uz) {
+        container.prealloc_dead(prealloc_per_species);
+      }
       // insert_or_assign and not operator[], because if element is missing,
       // then operator[] will default construct it.
       // pic::ParticleContainer is not default constructible.
-      std::ignore = where_to.insert_or_assign(
-        i,
-        pic::ParticleContainer { pcontainer_args.value() });
+      std::ignore = where_to.insert_or_assign(i, std::move(container));
 
     } else {
       break;
@@ -472,22 +477,6 @@ runko::prtc_id_type
   }
 
   return (tile_tag << 40uz) | ordinal;
-}
-
-template<std::size_t D>
-void
-  Tile<D>::inject_dead_particles(
-    const std::size_t particle_type,
-    const std::size_t amount)
-{
-  // This is somewhat jank but it works.
-  using state_type = runko::ParticleState<ParticleContainer::value_type>;
-  static constexpr auto dead =
-    state_type { .pos { 0, 0, 0 }, .vel { 0, 0, 0 }, .id = runko::dead_prtc_id };
-  const auto vec = thrust::device_vector<state_type>(amount, dead);
-  const auto arr =
-    std::array { std::span(thrust::raw_pointer_cast(vec.data()), vec.size()) };
-  this->particle_buffs_.at(particle_type).append(arr);
 }
 
 

--- a/core/pic/tile.h
+++ b/core/pic/tile.h
@@ -148,9 +148,6 @@ public:
     double x_right);
 
 
-  /// Injects dead particles. Can be used to pre-allocate memory for particles.
-  void inject_dead_particles(std::size_t particle_type, std::size_t amount);
-
   /// Push particles updating their velocities and positions.
   void push_particles();
 

--- a/projects/pic-shock/pic.py
+++ b/projects/pic-shock/pic.py
@@ -186,10 +186,16 @@ if __name__ == "__main__":
         prealloc_caps.append(int(budget_bytes / local_tiles_count / n_species / 32))
     prealloc_n = min(prealloc_caps) if prealloc_caps else 0
 
+    # Pass per-species prealloc size through the config so each Tile sizes its
+    # particle containers at construction time with dead-filled slots; later
+    # batch_inject_in_x_stripe calls write into those slots in place without
+    # reallocation.
+    conf.prealloc_per_species = prealloc_n
+
     if runko.on_main_rank() and prealloc_n > 0:
         logger.info(
             f"Pre-allocating {prealloc_n} dead particles per species per tile "
-            f"({prealloc_n * n_species * 32 / 1e6:.1f} MB/tile, "
+            f"at construction ({prealloc_n * n_species * 32 / 1e6:.1f} MB/tile, "
             f"{prealloc_n * n_species * 32 * local_tiles_count / 1e9:.2f} GB/rank)"
         )
 
@@ -201,9 +207,6 @@ if __name__ == "__main__":
                 tile.register_reflector_wall(wall)
                 tile.register_edge_bc(conducting_bc)
                 tile.register_edge_bc(upstream_bc)
-                if prealloc_n > 0:
-                    for species_id in range(n_species):
-                        tile.inject_dead_particles(species_id, prealloc_n)
                 for _ in range(ppc):
                     tile.batch_inject_in_x_stripe(0, pgen0, walloc, injloc0)
                     tile.batch_inject_in_x_stripe(1, pgen1, walloc, injloc0)

--- a/projects/pic-shock/pic.py
+++ b/projects/pic-shock/pic.py
@@ -305,7 +305,7 @@ if __name__ == "__main__":
 
         if simulation.lap % output_interval == 0:
             x.io_emf_snapshot()
-            x.io_prtcl_snapshot()
+            #x.io_prtcl_snapshot()
             x.io_spectra_snapshot()
             simulation.log_timer_statistics()
             simulation.reset_timers()


### PR DESCRIPTION
## Summary

This PR 
- moves PIC particle pre-allocation into the tile constructor and 
- teaches `ParticleContainer::add_particles<T...>` to reuse trailing dead slots in place. 
- eliminates a 2× GPU-memory peak that OOM'd runs pre-allocating close to the device ceiling. 
- Deletes the `Tile::inject_dead_particles` API along the way.

## Problem

`projects/pic-shock/pic.py` pre-allocates particle storage so the containers never need to resize mid-simulation. The old sequence was:

```python
tile = runko.pic.threeD.Tile(idx, conf)        # containers empty
tile.inject_dead_particles(species_id, N)      # size → N, all dead
for _ in range(ppc):
    tile.batch_inject_in_x_stripe(...)         # overwrites dead slots
```

Both phases briefly doubled GPU memory:

1. **`inject_dead_particles(N)`** (`core/pic/tile.c++`, old) built a `thrust::device_vector<ParticleState>` of N dead particles, then handed it to `ParticleContainer::append()`, which *also* allocated target-size `pos_/vel_/ids_`. Peak ≈ 2 × N × 56 B.
2. **`batch_inject_in_x_stripe`** → `ParticleContainer::add_particles<T...>` (`core/pic/particle.h`) unconditionally allocated fresh `new_pos/vel/ids` sized `Nprev + Σ Nothers`, copied *everything* in `*this` (including the pre-allocated dead tail) into them, then swapped. Peak ≈ 2 × (P + R) × 56 B, where P = prealloc size, R = real particles.

When P is set near the device memory ceiling (the whole point of pre-alloc), either phase exceeds the ceiling and the job dies. On top of that, the shock driver's real-particle injection path (`batch_inject_in_x_stripe`) never reached the only code that *did* reuse dead slots — `append()`, used solely by halo exchange — so the "pre-allocated slots" were not actually consumed in place; they were carried along through every resize.

## Fix

Before allocating anything, reverse-scan for the count of trailing dead slots (`dead_tail = size() - Pnum`, where `Pnum` is the count up through the last alive particle). Two paths:

**Fast path** — when `Σ Nothers ≤ dead_tail`: no allocation. Copy each other's particles directly into `this->pos_/vel_/ids_` at the offset where the dead tail begins. Peak memory is unchanged from entry.

**Slow path** — allocate `new_pos/vel/ids` sized `Pnum + Σ Nothers` (note: *not* `size() + Σ Nothers`). Copy only the alive prefix `[0, Pnum)` from the old storage, then write each other into its target sub-range. The dead tail is dropped rather than carried forward — strictly less work than before and a strictly smaller new allocation when dead slots exist.

All three copy sites (fast-path, slow-path alive-prefix, slow-path other-handling) share a single `copy_particles_into` lambda parameterized by target mdspans and target range.
