### PR TITLE
Implement json trace

### DIFF
--- a/projects/pic-turbulence/pic.py
+++ b/projects/pic-turbulence/pic.py
@@ -42,6 +42,7 @@ if __name__ == "__main__":
     config.current_depositer = "zigzag_1st_atomic"
     config.current_filter = "binomial2"
     config.tile_partitioning = "hilbert_curve"
+    config.laps_in_timer_statistics = 20
 
 
     # Problem specific configuration
@@ -234,8 +235,7 @@ if __name__ == "__main__":
         if simulation.lap % 20 == 0:
             x.io_emf_snapshot()
 
-        if simulation.lap % 20 == 0:
-            simulation.log_timer_statistics()
+        simulation.log_timer_statistics()
 
     simulation.for_each_lap(pic_simulation_step)
     simulation.log_timer_statistics()

--- a/runko/runko_timer.py
+++ b/runko/runko_timer.py
@@ -79,6 +79,14 @@ class Timer:
         return {name: t.end - t.begin for name, t in self.__times.items()}
 
 
+    @property
+    def time_measurements(self):
+        """
+        Dictionary that maps strings to runko.TimeMeasurement.
+        """
+        return self.__times
+
+
 @dataclass
 class TimerStatistic:
     total: float

--- a/runko/simulation.py
+++ b/runko/simulation.py
@@ -59,7 +59,7 @@ class Simulation:
         self._logger = runko_logger("Simulation")
 
         self._rank = MPI.COMM_WORLD.Get_rank()
-        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}.csv")
+        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_host.csv")
         self._ram_file.parent.mkdir(exist_ok=True, parents=True)
         self._ram_file.write_text("lap,ram usage [kB]\n")
 

--- a/runko/simulation.py
+++ b/runko/simulation.py
@@ -59,15 +59,9 @@ class Simulation:
         self._logger = runko_logger("Simulation")
 
         self._rank = MPI.COMM_WORLD.Get_rank()
-        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_host.csv")
-        self._ram_file.parent.mkdir(exist_ok=True, parents=True)
-        self._ram_file.write_text("lap,ram usage [kB]\n")
 
-        if get_gpu_mem_kB() is not None:
-            self._gpu_ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_gpu.csv")
-            self._gpu_ram_file.write_text("lap,gpu mem usage [kB]\n")
-        else:
-            self._gpu_ram_file = None
+        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_host.csv")
+        self._gpu_ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_gpu.csv")
 
         self._io_config['kinetic_energy_path'] = self._io_config["outdir"] + "/average_kinetic_energy.txt"
         self._io_config['average_B_energy_density_path'] = self._io_config["outdir"] + "/average_B_energy_density.txt"
@@ -180,9 +174,21 @@ class Simulation:
 
     def _write_ram_usage(self):
         """Append current RAM usage (RSS in kB) for this lap to the per-rank CSV."""
+
+        if not self._ram_file.exists():
+            self._ram_file.parent.mkdir(exist_ok=True, parents=True)
+            self._ram_file.write_text("lap,ram usage [kB]\n")
+
         with open(self._ram_file, "a") as f:
             f.write(f"{self.lap},{get_rss_kB()}\n")
-        if self._gpu_ram_file is not None:
+
+        gpu_mem = get_gpu_mem_kB()
+
+        if gpu_mem:
+            if not self._gpu_ram_file.exists():
+                self._gpu_ram_file.parent.mkdir(exist_ok=True, parents=True)
+                self._gpu_ram_file.write_text("lap,gpu mem usage [kB]\n")
+
             with open(self._gpu_ram_file, "a") as f:
                 f.write(f"{self.lap},{get_gpu_mem_kB()}\n")
 

--- a/runko/simulation.py
+++ b/runko/simulation.py
@@ -60,8 +60,8 @@ class Simulation:
 
         self._rank = MPI.COMM_WORLD.Get_rank()
 
-        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_host.csv")
-        self._gpu_ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_gpu.csv")
+        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/mem-usage/cpu/{self._rank}.csv")
+        self._gpu_ram_file = pathlib.Path(f"{self._io_config['outdir']}/mem-usage/gpu/{self._rank}.csv")
 
         self._io_config['kinetic_energy_path'] = self._io_config["outdir"] + "/average_kinetic_energy.txt"
         self._io_config['average_B_energy_density_path'] = self._io_config["outdir"] + "/average_B_energy_density.txt"

--- a/runko/simulation.py
+++ b/runko/simulation.py
@@ -328,8 +328,11 @@ class Simulation:
             self.for_one_lap(lap_function)
 
 
-    def get_time_statistics(self):
-        return timer_statistics(self._lap_timers)
+    def get_time_statistics(self, n_latests=None):
+        if n_latests:
+            return timer_statistics(self._lap_timers[-n_latests:])
+        else:
+            return timer_statistics(self._lap_timers)
 
 
     def reset_timers(self):
@@ -337,8 +340,9 @@ class Simulation:
         self._lap_wall_times = []
         self._prev_elapsed_wall_time = self._total_interval_time
 
+
     def log_timer_statistics(self, level=logging.INFO):
-        stats_dict = self.get_time_statistics()
+        stats_dict = self.get_time_statistics(self._io_config["laps_in_timer_statistics"])
         if len(stats_dict) == 0:
             self._logger.warning("Trying to log timer non-existing statistic.")
             return

--- a/runko/simulation.py
+++ b/runko/simulation.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .method_wrapper import MethodWrapper
-from .runko_logging import runko_logger
+from .runko_logging import runko_logger, on_main_rank
 from .runko_timer import Timer, timer_statistics
 
 from runko_cpp_bindings.tools import _virtual_tile_sync_handshake_mode, comm_mode
@@ -11,6 +11,7 @@ from runko_cpp_bindings.emf.threeD import MpiioParticlesWriter as ParticlesWrite
 from runko_cpp_bindings.emf.threeD import MpiioSpectraWriter as SpectraWriter
 from runko_cpp_bindings.pic.threeD import _write_average_kinetic_energy
 
+import json
 import logging
 import time
 import numpy as np
@@ -51,18 +52,19 @@ class Simulation:
 
         self._lap_timers = []
         self._lap_wall_times = []
+        self._lap_finish_times = []
 
         self.verbose_laps = kwargs.get('verbose', True)
 
         self._logger = runko_logger("Simulation")
 
-        rank = MPI.COMM_WORLD.Get_rank()
-        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{rank}.csv")
+        self._rank = MPI.COMM_WORLD.Get_rank()
+        self._ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}.csv")
         self._ram_file.parent.mkdir(exist_ok=True, parents=True)
         self._ram_file.write_text("lap,ram usage [kB]\n")
 
         if get_gpu_mem_kB() is not None:
-            self._gpu_ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{rank}_gpu.csv")
+            self._gpu_ram_file = pathlib.Path(f"{self._io_config['outdir']}/ram-usage/{self._rank}_gpu.csv")
             self._gpu_ram_file.write_text("lap,gpu mem usage [kB]\n")
         else:
             self._gpu_ram_file = None
@@ -74,6 +76,9 @@ class Simulation:
         # Reset txt output files.
         for name in ('kinetic_energy_path', 'average_B_energy_density_path', 'average_E_energy_density_path'):
             pathlib.Path(self._io_config[name]).unlink(missing_ok=True)
+
+
+        self._trace_file = pathlib.Path(f"{self._io_config['outdir']}/traces/{self._rank}.json")
 
         ctor_msg = "Simulation constructed with:\n"
         ctor_msg += f"\tNt = {kwargs['Nt']}\n"
@@ -295,6 +300,7 @@ class Simulation:
         if not disable_timing:
             self._lap_timers.append(lap_timer)
             self._lap_wall_times.append(lap_wall_time_end - lap_wall_time_begin)
+            self._lap_finish_times.append(lap_wall_time_end)
 
 
     def prelude(self, lap_function):
@@ -375,3 +381,74 @@ class Simulation:
         lap_per_max_lap = self._lap/self._last_lap # simulation progress in fraction 
         msg += f"Current lap: {self._lap} / {self._last_lap} ({lap_per_max_lap:.1%})"
         self._logger.log(level, msg)
+
+
+    def write_trace_json(self, combine: bool = True) -> dict:
+        """
+        Writes trace data of each process into `<outdir>/traces/<mpi-rank>.json`
+        in Trace Event Format [0] which can be viewed with e.g. Pefetto UI.
+
+        If `combine` is `True`, this has to be called on every rank
+        and the trace jsons are combined into `<outdir>/traces/combined.json`.
+
+        [0]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+        """
+
+        obj = dict(traceEvents=[{
+            "name": "process_name",
+            "ph": "M",
+            "pid": 0, # unused
+            "tid": self._rank, # Use tid as proxy for mpi rank.
+            "args": { "name": f"MPI ranks" }
+        },{
+            "name": "thread_name",
+            "ph": "M",
+            "pid": 0, # unused
+            "tid": self._rank, # Use tid as proxy for mpi rank.
+            "args": { "name": f"MPI rank {self._rank}" }
+        }])
+
+        for timer in self._lap_timers:
+            for name, measurement in timer.time_measurements.items():
+                cat, _ = name.split("_", 1)
+
+                obj["traceEvents"].append({
+                    "name": name,
+                    "cat": cat,
+                    "ph": "X",
+                    "pid": 0, # unused
+                    "tid": self._rank, # Use tid as proxy for mpi rank.
+                    "ts": 1e6 * measurement.begin,
+                    "dur": 1e6 * (measurement.end - measurement.begin),
+                })
+
+        for t in self._lap_finish_times:
+            obj["traceEvents"].append({
+                "name": f"lap_finish",
+                "cat": "meta",
+                "ph": "i",
+                "pid": 0, # unused
+                "tid": self._rank, # Use tid as proxy for mpi rank.
+                "ts": 1e6 * t,
+            })
+
+        self._trace_file.parent.mkdir(exist_ok=True, parents=True)
+        with open(self._trace_file, "w") as f:
+            json.dump(obj, f)
+
+        if not combine:
+            return
+
+        MPI.COMM_WORLD.barrier()
+        if on_main_rank():
+            combined = {"traceEvents": []}
+
+            for i in range(MPI.COMM_WORLD.Get_size()):
+                p = pathlib.Path(f"{self._io_config['outdir']}/traces/{i}.json")
+                with open(p, "r") as f:
+                    data = json.load(f)
+                    combined["traceEvents"] += data["traceEvents"]
+
+            with open(f"{self._io_config['outdir']}/traces/combined.json", "w") as f:
+                json.dump(combined, f)
+

--- a/runko/tile_grid.py
+++ b/runko/tile_grid.py
@@ -207,6 +207,7 @@ class TileGrid:
                          outdir=resolve_outdir(config),
                          nspecies=nspecies,
                          n_prtcls=config.n_prtcls if config.n_prtcls else 0,
+                         laps_in_timer_statistics=getattr(config, 'laps_in_timer_statistics', None),
                          spectra_nbins=getattr(config, 'spectra_nbins', 200),
                          spectra_umin=getattr(config, 'spectra_umin', 1e-4),
                          spectra_umax=getattr(config, 'spectra_umax', 1e3),


### PR DESCRIPTION
This pr adds method to `simulation` class that writes the timing data in [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.yr4qxyxotyw).

This is somewhat of a abuse of trace format and trace visualization tools but it gives a nice tool to inspect potential load imbalances. For example, the data can be viewed with Perfetto UI which looks like this for some dummy simulation on LUMI with 2 nodes:

<img width="2497" height="640" alt="foo" src="https://github.com/user-attachments/assets/6c117ce3-6013-47c9-8524-f052df619977" />


In order to make the implementation simpler, this pr adds a new configuration parameter `laps_in_timer_statistics` which controls the number of laps that are taken into account for the timing statistics.
Previously similar functionality was emulated with `reset_timers` method. 