### PR TITLE
fix(mpiio): strncpy -> memcpy to prevent warnings on gcc-14

### DIFF
--- a/src/runko/io/snapshots/mpiio_fields.c++
+++ b/src/runko/io/snapshots/mpiio_fields.c++
@@ -11,9 +11,12 @@
 #include "tyvi/mdgrid.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <format>
+#include <iterator>
 #include <string>
+#include <string_view>
 #include <vector>
 
 
@@ -29,15 +32,18 @@ int mpiio::write_header(
   int32_t lap,
   int32_t num_fields)
 {
-  char buf[512];
-  std::memset(buf, 0, sizeof(buf));
+  auto buf = std::array<char, 512>{};
+
+  auto buf_ptr_at = [&](const auto n) {
+    return std::ranges::next(buf.data(), n);
+  };
 
   auto put32 = [&](int offset, uint32_t val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
 
   auto puti32 = [&](int offset, int32_t val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
 
   put32(0, magic);
@@ -60,15 +66,18 @@ int mpiio::write_header(
 
   // Field names: num_fields entries of 16 chars each, starting at offset 64
   for (int f = 0; f < num_emf_fields; f++) {
-    std::strncpy(buf + 64 + f * 16, emf_field_names[f], 15);
+    const auto name = std::string_view{emf_field_names[f]};
+    const auto n = std::ranges::min(name.size(), 15uz);
+    std::memcpy(buf_ptr_at(64 + f * 16), name.data(), n);
   }
   for (int s = 0; s < num_fields - num_emf_fields; s++) {
-    auto name = std::format("n{}", s);
-    std::strncpy(buf + 64 + (num_emf_fields + s) * 16, name.c_str(), 15);
+    const auto name = std::format("n{}", s);
+    const auto n = std::ranges::min(name.size(), 15uz);
+    std::memcpy(buf_ptr_at(64 + (num_emf_fields + s) * 16), name.data(), n);
   }
 
   MPI_Status status;
-  return MPI_File_write_at(fh, 0, buf, 512, MPI_BYTE, &status);
+  return MPI_File_write_at(fh, 0, buf.data(), 512, MPI_BYTE, &status);
 }
 
 

--- a/src/runko/io/snapshots/mpiio_particles.c++
+++ b/src/runko/io/snapshots/mpiio_particles.c++
@@ -30,17 +30,20 @@ static int write_prtcl_header(
   int32_t lap,
   int32_t num_fields)
 {
-  char buf[512];
-  std::memset(buf, 0, sizeof(buf));
+  auto buf = std::array<char, 512>{};
+
+  auto buf_ptr_at = [&](const auto n) {
+    return std::ranges::next(buf.data(), n);
+  };
 
   auto put32 = [&](int offset, uint32_t val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
   auto puti32 = [&](int offset, int32_t val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
   auto puti64 = [&](int offset, int64_t val) {
-    std::memcpy(buf + offset, &val, 8);
+    std::memcpy(buf_ptr_at(offset), &val, 8);
   };
 
   put32(0, mpiio::magic);
@@ -63,11 +66,13 @@ static int write_prtcl_header(
 
   // Field names: 12 entries of 16 chars each, starting at offset 64
   for (int f = 0; f < num_fields; f++) {
-    std::strncpy(buf + 64 + f * 16, mpiio::prtcl_field_names[f], 15);
+    const auto name = std::string_view{mpiio::prtcl_field_names[f]};
+    const auto n = std::ranges::min(name.size(), 15uz);
+    std::memcpy(buf_ptr_at(64 + f * 16), name.data(), n);
   }
 
   MPI_Status status;
-  return MPI_File_write_at(fh, 0, buf, 512, MPI_BYTE, &status);
+  return MPI_File_write_at(fh, 0, buf.data(), 512, MPI_BYTE, &status);
 }
 
 

--- a/src/runko/io/snapshots/mpiio_spectra.c++
+++ b/src/runko/io/snapshots/mpiio_spectra.c++
@@ -12,6 +12,7 @@
 #include "tyvi/mdgrid.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <format>
@@ -33,19 +34,22 @@ int mpiio::write_spectra_header(
   float umin,
   float umax)
 {
-  char buf[512];
-  std::memset(buf, 0, sizeof(buf));
+  auto buf = std::array<char, 512>{};
+
+  auto buf_ptr_at = [&](const auto n) {
+    return std::ranges::next(buf.data(), n);
+  };
 
   auto put32 = [&](int offset, uint32_t val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
 
   auto puti32 = [&](int offset, int32_t val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
 
   auto putf32 = [&](int offset, float val) {
-    std::memcpy(buf + offset, &val, 4);
+    std::memcpy(buf_ptr_at(offset), &val, 4);
   };
 
   put32(0, magic);
@@ -72,7 +76,8 @@ int mpiio::write_spectra_header(
     for (int q = 0; q < num_spectra_per_species; q++) {
       auto name = std::format("s{}_{}", s, spectra_suffixes[q]);
       int f = s * num_spectra_per_species + q;
-      std::strncpy(buf + 64 + f * 16, name.c_str(), 15);
+      const auto n = std::ranges::min(name.size(), 15uz);
+      std::memcpy(buf_ptr_at(64 + f * 16), name.data(), n);
     }
   }
 
@@ -82,7 +87,7 @@ int mpiio::write_spectra_header(
   putf32(264, umax);
 
   MPI_Status status;
-  return MPI_File_write_at(fh, 0, buf, 512, MPI_BYTE, &status);
+  return MPI_File_write_at(fh, 0, buf.data(), 512, MPI_BYTE, &status);
 }
 
 


### PR DESCRIPTION
gcc-14 did not like std::strncpy usage. This pr changes them to std::memcpy, but keeps the functionality the same by manually limiting the maximum number of bytes to copy.

Example of warning that gcc-14 gave:

```
/runko/src/runko/io/snapshots/mpiio_fields.c++:67:17: error: ‘char* __builtin___strncpy_chk(char, const char, long unsigned int, long unsigned int)’ output may be truncated copying 15 bytes from a string of length 15 [-Werror=stringop-truncation]
67 | std::strncpy(buf + 64 + (num_emf_fields + s) * 16, name.c_str(), 15);
```